### PR TITLE
feat: Slice 2 - Slack Integration Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,7 @@ A GitHub Personal Access Token (PAT) is required to access the GHSA via their Gr
 3.  Set the environment variable: `export GITHUB_TOKEN=your_token_here`
 
 #### **Slack Integration (Optional)**
-To receive vulnerability alerts in Slack:
-1.  Create a Slack App at [api.slack.com/apps](https://api.slack.com/apps).
-2.  In **OAuth & Permissions**, add the `chat:write` bot token scope.
-3.  Install the app to your workspace and copy the **Bot User OAuth Token**.
-4.  Copy the **Signing Secret** from the Basic Information page.
-5.  Set the environment variables:
-    ```bash
-    export SLACK_BOT_TOKEN=xoxb-your-token
-    export SLACK_SIGNING_SECRET=your-signing-secret
-    ```
+To receive vulnerability alerts in Slack, follow the detailed setup instructions in [docs/slack-setup.md](docs/slack-setup.md).
 
 ### 4. Run the Application
 ```bash

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ A GitHub Personal Access Token (PAT) is required to access the GHSA via their Gr
 2.  Generate a new token with at least `public_repo` (for public advisories) or `read:packages` scope.
 3.  Set the environment variable: `export GITHUB_TOKEN=your_token_here`
 
+#### **Slack Integration (Optional)**
+To receive vulnerability alerts in Slack:
+1.  Create a Slack App at [api.slack.com/apps](https://api.slack.com/apps).
+2.  In **OAuth & Permissions**, add the `chat:write` bot token scope.
+3.  Install the app to your workspace and copy the **Bot User OAuth Token**.
+4.  Copy the **Signing Secret** from the Basic Information page.
+5.  Set the environment variables:
+    ```bash
+    export SLACK_BOT_TOKEN=xoxb-your-token
+    export SLACK_SIGNING_SECRET=your-signing-secret
+    ```
+
 ### 4. Run the Application
 ```bash
 ./gradlew bootRun
@@ -142,6 +154,7 @@ Once the application is running, you can access the interactive API documentatio
 | `GET` | `/api/v1/vulnerabilities/search?q=...` | Full-text search across titles and descriptions |
 | `POST`| `/api/v1/admin/ingest/trigger` | Manually trigger an ingestion cycle |
 | `GET` | `/api/v1/admin/ingest/status` | Monitor the state of background ingest jobs |
+| `POST`| `/api/v1/admin/ingest/slack/test` | Send a test message to Slack (`?channel=ID`) |
 
 ### Sample Request & Response
 
@@ -178,6 +191,9 @@ Once the application is running, you can access the interactive API documentatio
 
 - [x] **Slice 1: Foundation**: Core ingestion, dedup, and REST API.
 - [ ] **Slice 2: Slack Alerts**: Proactive notifications for watched packages.
+  - [x] Foundation (Bolt SDK integration)
+  - [ ] Watchlist Management API
+  - [ ] Automated Matching & Alerting
 - [ ] **Slice 3: AI Enrichment**: LLM-generated summaries and remediation advice.
 - [ ] **Slice 4: Dashboard**: Web UI for triage and management.
 - [ ] **Slice 5: MCP Server**: Enable agentic AI to query vulnerability data.

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ dependencies {
     implementation 'org.flywaydb:flyway-database-postgresql'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.5'
     
+    // Slack SDK
+    implementation 'com.slack.api:bolt-jakarta-servlet:1.45.3'
+    implementation 'com.slack.api:slack-api-client:1.45.3'
+    
     compileOnly 'org.projectlombok:lombok:1.18.38'
     annotationProcessor 'org.projectlombok:lombok:1.18.38'
     

--- a/docs/slack-setup.md
+++ b/docs/slack-setup.md
@@ -1,0 +1,76 @@
+# Slack Integration Setup Guide
+
+This guide provides step-by-step instructions for setting up the Slack integration for **Vulnerability-Bench**.
+
+---
+
+## 1. Create a Slack App
+
+1.  Go to the [Slack API Dashboard](https://api.slack.com/apps).
+2.  Click **Create New App** and select **From scratch**.
+3.  Name your app (e.g., `Vulnerability-Bench`) and select your workspace.
+4.  Click **Create App**.
+
+## 2. Configure Scopes
+
+1.  In the left sidebar, go to **Features > OAuth & Permissions**.
+2.  Scroll down to **Scopes > Bot Token Scopes**.
+3.  Add the following scopes:
+    *   `chat:write`: Required to send alerts to channels.
+    *   `chat:write.public`: (Recommended) Allows the bot to post in public channels without needing to join them first.
+    *   `commands`: (Future) Required for slash commands like `/vulnbench watch`.
+
+## 3. Install App to Workspace
+
+1.  Scroll back to the top of the **OAuth & Permissions** page.
+2.  Click **Install to Workspace**.
+3.  Click **Allow** to authorize the bot.
+4.  Copy the **Bot User OAuth Token** (starts with `xoxb-`). You will need this for your environment variables.
+
+## 4. Get the Signing Secret
+
+1.  In the left sidebar, go to **Settings > Basic Information**.
+2.  Scroll down to **App Credentials**.
+3.  Copy the **Signing Secret**. You will need this for your environment variables.
+
+## 5. Configure Environment Variables
+
+Add the following to your `.env` file or export them in your shell:
+
+```bash
+# Slack API Credentials
+SLACK_BOT_TOKEN=xoxb-your-bot-token
+SLACK_SIGNING_SECRET=your-signing-secret
+```
+
+## 6. Testing the Integration
+
+### Finding a Channel ID
+1.  Open Slack and right-click on the channel where you want to receive alerts.
+2.  Select **View Channel Details**.
+3.  The **Channel ID** is located at the bottom of the popup (e.g., `C07A1234567`).
+
+### Sending a Test Message
+Once the application is running, you can trigger a test message using the Admin API:
+
+```bash
+curl -X POST "http://localhost:8080/api/v1/admin/ingest/slack/test?channel=YOUR_CHANNEL_ID"
+```
+
+If successful, the bot will post a rocket emoji message to the specified channel.
+
+---
+
+## Troubleshooting
+
+### `channel_not_found`
+If you receive this error when testing:
+*   Ensure the Channel ID is correct.
+*   If it is a **private channel**, you must invite the bot first by typing `/invite @YourBotName` in the channel.
+
+### `invalid_auth`
+*   Verify that `SLACK_BOT_TOKEN` is exactly as shown in the OAuth page.
+*   Ensure the app has been installed to the workspace after adding scopes.
+
+### `app_mention` (Optional Future Feature)
+If you plan to use interactive features (like buttons or mentions), you will need to set up an **Event Subscriptions** URL (e.g., using `ngrok` for local development). This is not required for the basic alerting foundation implemented in Slice 2.

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/AdminController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/AdminController.java
@@ -7,6 +7,7 @@ import dev.prasadgaikwad.vulnbench.repository.IngestStateRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
  * Controller for administrative tasks such as manual ingestion triggers
  * and monitoring the state of background jobs.
  */
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/admin/ingest")
 @RequiredArgsConstructor
@@ -37,6 +39,7 @@ public class AdminController {
     @PostMapping("/trigger")
     @Operation(summary = "Manually trigger a full ingest cycle (runs asynchronously)")
     public ResponseEntity<Map<String, String>> trigger() {
+        log.info("[Admin] Manually triggering full ingest cycle");
         CompletableFuture.runAsync(() -> ingestService.runFullIngest());
         return ResponseEntity.accepted()
                 .body(Map.of("message", "Ingest triggered. Check /status for progress."));
@@ -50,6 +53,7 @@ public class AdminController {
     @GetMapping("/status")
     @Operation(summary = "Get the current ingest state for all sources")
     public List<IngestState> status() {
+        log.debug("[Admin] Fetching ingest status");
         return ingestStateRepo.findAll();
     }
 
@@ -62,7 +66,13 @@ public class AdminController {
     @PostMapping("/slack/test")
     @Operation(summary = "Send a test message to a Slack channel")
     public ResponseEntity<Map<String, String>> testSlack(@RequestParam String channel) {
-        slackService.sendTestMessage(channel);
-        return ResponseEntity.ok(Map.of("message", "Test message sent to " + channel));
+        log.info("[Admin] Sending Slack test message to channel: {}", channel);
+        try {
+            slackService.sendTestMessage(channel);
+            return ResponseEntity.ok(Map.of("message", "Test message sent to " + channel));
+        } catch (Exception e) {
+            log.error("[Admin] Failed to send Slack test message", e);
+            throw e;
+        }
     }
 }

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/AdminController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/AdminController.java
@@ -21,6 +21,7 @@ public class AdminController {
 
     private final IngestService ingestService;
     private final IngestStateRepository ingestStateRepo;
+    private final dev.prasadgaikwad.vulnbench.notification.slack.SlackService slackService;
 
     @PostMapping("/trigger")
     @Operation(summary = "Manually trigger a full ingest cycle (runs asynchronously)")
@@ -34,5 +35,12 @@ public class AdminController {
     @Operation(summary = "Get the current ingest state for all sources")
     public List<IngestState> status() {
         return ingestStateRepo.findAll();
+    }
+
+    @PostMapping("/slack/test")
+    @Operation(summary = "Send a test message to a Slack channel")
+    public ResponseEntity<Map<String, String>> testSlack(@RequestParam String channel) {
+        slackService.sendTestMessage(channel);
+        return ResponseEntity.ok(Map.of("message", "Test message sent to " + channel));
     }
 }

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/AdminController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/AdminController.java
@@ -65,7 +65,7 @@ public class AdminController {
      */
     @PostMapping("/slack/test")
     @Operation(summary = "Send a test message to a Slack channel")
-    public ResponseEntity<Map<String, String>> testSlack(@RequestParam String channel) {
+    public ResponseEntity<Map<String, String>> testSlack(@RequestParam("channel") String channel) {
         log.info("[Admin] Sending Slack test message to channel: {}", channel);
         try {
             slackService.sendTestMessage(channel);

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/AdminController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/AdminController.java
@@ -2,6 +2,7 @@ package dev.prasadgaikwad.vulnbench.api;
 
 import dev.prasadgaikwad.vulnbench.batch.IngestService;
 import dev.prasadgaikwad.vulnbench.domain.IngestState;
+import dev.prasadgaikwad.vulnbench.notification.slack.SlackService;
 import dev.prasadgaikwad.vulnbench.repository.IngestStateRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +14,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * Controller for administrative tasks such as manual ingestion triggers
+ * and monitoring the state of background jobs.
+ */
 @RestController
 @RequestMapping("/api/v1/admin/ingest")
 @RequiredArgsConstructor
@@ -21,8 +26,14 @@ public class AdminController {
 
     private final IngestService ingestService;
     private final IngestStateRepository ingestStateRepo;
-    private final dev.prasadgaikwad.vulnbench.notification.slack.SlackService slackService;
+    private final SlackService slackService;
 
+    /**
+     * Triggers a full ingestion cycle for all enabled security sources.
+     * The process runs asynchronously.
+     * 
+     * @return a 202 Accepted response with a confirmation message
+     */
     @PostMapping("/trigger")
     @Operation(summary = "Manually trigger a full ingest cycle (runs asynchronously)")
     public ResponseEntity<Map<String, String>> trigger() {
@@ -31,12 +42,23 @@ public class AdminController {
                 .body(Map.of("message", "Ingest triggered. Check /status for progress."));
     }
 
+    /**
+     * Retrieves the current ingestion status for all supported sources.
+     * 
+     * @return a list of {@link IngestState} objects representing the last run status
+     */
     @GetMapping("/status")
     @Operation(summary = "Get the current ingest state for all sources")
     public List<IngestState> status() {
         return ingestStateRepo.findAll();
     }
 
+    /**
+     * Sends a test message to a specified Slack channel to verify integration.
+     * 
+     * @param channel the Slack channel ID (e.g., C12345)
+     * @return a confirmation response
+     */
     @PostMapping("/slack/test")
     @Operation(summary = "Send a test message to a Slack channel")
     public ResponseEntity<Map<String, String>> testSlack(@RequestParam String channel) {

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityController.java
@@ -26,10 +26,10 @@ public class VulnerabilityController {
     @GetMapping
     @Operation(summary = "List vulnerabilities with optional filters")
     public Page<VulnerabilityResponse> list(
-            @Parameter(description = "Severity filter: CRITICAL, HIGH, MEDIUM, LOW, NONE") @RequestParam(required = false) String severity,
-            @Parameter(description = "Ecosystem filter: npm, Maven, PyPI, Go, ...") @RequestParam(required = false) String ecosystem,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size) {
+            @Parameter(description = "Severity filter: CRITICAL, HIGH, MEDIUM, LOW, NONE") @RequestParam(value = "severity", required = false) String severity,
+            @Parameter(description = "Ecosystem filter: npm, Maven, PyPI, Go, ...") @RequestParam(value = "ecosystem", required = false) String ecosystem,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, Math.min(size, 100),
                 Sort.by(Sort.Direction.DESC, "publishedAt"));
 
@@ -47,7 +47,7 @@ public class VulnerabilityController {
 
     @GetMapping("/{cveId}")
     @Operation(summary = "Get full details for a specific CVE")
-    public ResponseEntity<VulnerabilityDetailResponse> detail(@PathVariable String cveId) {
+    public ResponseEntity<VulnerabilityDetailResponse> detail(@PathVariable("cveId") String cveId) {
         return vulnRepo.findByCveId(cveId)
                 .map(VulnerabilityDetailResponse::from)
                 .map(ResponseEntity::ok)
@@ -57,9 +57,9 @@ public class VulnerabilityController {
     @GetMapping("/search")
     @Operation(summary = "Full-text search across CVE title and description")
     public Page<VulnerabilityResponse> search(
-            @RequestParam String q,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size) {
+            @RequestParam("q") String q,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size) {
         Pageable pageable = PageRequest.of(page, Math.min(size, 100));
         return vulnRepo.fullTextSearch(q, pageable).map(VulnerabilityResponse::from);
     }

--- a/src/main/java/dev/prasadgaikwad/vulnbench/config/SlackConfig.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/config/SlackConfig.java
@@ -6,6 +6,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Configuration class for initializing the Slack Bolt {@link App}.
+ * Reads Slack API credentials from environment variables.
+ */
 @Configuration
 public class SlackConfig {
 
@@ -15,6 +19,11 @@ public class SlackConfig {
     @Value("${SLACK_SIGNING_SECRET:}")
     private String signingSecret;
 
+    /**
+     * Initializes the Slack Bolt App with the provided bot token and signing secret.
+     * 
+     * @return a configured {@link App} instance
+     */
     @Bean
     public App initSlackApp() {
         AppConfig config = AppConfig.builder()

--- a/src/main/java/dev/prasadgaikwad/vulnbench/config/SlackConfig.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/config/SlackConfig.java
@@ -1,0 +1,26 @@
+package dev.prasadgaikwad.vulnbench.config;
+
+import com.slack.api.bolt.App;
+import com.slack.api.bolt.AppConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SlackConfig {
+
+    @Value("${SLACK_BOT_TOKEN:}")
+    private String botToken;
+
+    @Value("${SLACK_SIGNING_SECRET:}")
+    private String signingSecret;
+
+    @Bean
+    public App initSlackApp() {
+        AppConfig config = AppConfig.builder()
+                .singleTeamBotToken(botToken)
+                .signingSecret(signingSecret)
+                .build();
+        return new App(config);
+    }
+}

--- a/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
@@ -3,16 +3,11 @@ package dev.prasadgaikwad.vulnbench.notification.slack;
 import com.slack.api.bolt.App;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
-import com.slack.api.methods.request.chat.ChatPostMessageRequest;
-import com.slack.api.model.block.Blocks;
-import com.slack.api.model.block.SectionBlock;
-import com.slack.api.model.block.composition.MarkdownTextObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Service for interacting with Slack via the Bolt SDK.
@@ -29,15 +24,14 @@ public class SlackService {
      * Sends a plain text message to the specified Slack channel.
      * 
      * @param channel the ID or name of the Slack channel
-     * @param text the message content
+     * @param text    the message content
      */
     public void sendMessage(String channel, String text) {
         try {
             MethodsClient client = slackApp.client();
             var result = client.chatPostMessage(r -> r
                     .channel(channel)
-                    .text(text)
-            );
+                    .text(text));
             if (result.isOk()) {
                 log.info("[Slack] Message sent successfully to {}", channel);
             } else {

--- a/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
@@ -14,6 +14,10 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.util.List;
 
+/**
+ * Service for interacting with Slack via the Bolt SDK.
+ * Provides methods for sending plain text and formatted messages.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -21,6 +25,12 @@ public class SlackService {
 
     private final App slackApp;
 
+    /**
+     * Sends a plain text message to the specified Slack channel.
+     * 
+     * @param channel the ID or name of the Slack channel
+     * @param text the message content
+     */
     public void sendMessage(String channel, String text) {
         try {
             MethodsClient client = slackApp.client();
@@ -38,6 +48,11 @@ public class SlackService {
         }
     }
 
+    /**
+     * Sends a standardized test message to verify the Slack connection.
+     * 
+     * @param channel the target Slack channel
+     */
     public void sendTestMessage(String channel) {
         String text = "🚀 *Vulnerability-Bench* is now connected to Slack!";
         sendMessage(channel, text);

--- a/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
@@ -1,0 +1,45 @@
+package dev.prasadgaikwad.vulnbench.notification.slack;
+
+import com.slack.api.bolt.App;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.model.block.Blocks;
+import com.slack.api.model.block.SectionBlock;
+import com.slack.api.model.block.composition.MarkdownTextObject;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SlackService {
+
+    private final App slackApp;
+
+    public void sendMessage(String channel, String text) {
+        try {
+            MethodsClient client = slackApp.client();
+            var result = client.chatPostMessage(r -> r
+                    .channel(channel)
+                    .text(text)
+            );
+            if (result.isOk()) {
+                log.info("[Slack] Message sent successfully to {}", channel);
+            } else {
+                log.error("[Slack] Failed to send message: {}", result.getError());
+            }
+        } catch (IOException | SlackApiException e) {
+            log.error("[Slack] Error while sending message", e);
+        }
+    }
+
+    public void sendTestMessage(String channel) {
+        String text = "🚀 *Vulnerability-Bench* is now connected to Slack!";
+        sendMessage(channel, text);
+    }
+}


### PR DESCRIPTION
Resolves #1 

This PR implements the foundational Slack integration for **vulnerability-bench**.

### Changes:
- Added `bolt-jakarta-servlet` and `slack-api-client` dependencies to `build.gradle`.
- Created `SlackConfig` to initialize the Slack Bolt App.
- Implemented `SlackService` with a `sendMessage` and `sendTestMessage` capability.
- Added a test endpoint `POST /api/v1/admin/ingest/slack/test?channel=...` to verify connectivity.

### How to test:
1. Set `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` environment variables.
2. Run the app.
3. Call `POST http://localhost:8080/api/v1/admin/ingest/slack/test?channel=C12345`.