### PR TITLE
chore: finalize slice 2 with tests and import refactoring

### DIFF
--- a/src/main/java/dev/prasadgaikwad/vulnbench/ingest/dedup/DedupService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/ingest/dedup/DedupService.java
@@ -5,8 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
-
 /**
  * Deduplication service backed by Redis.
  * Fast-path check prevents redundant DB I/O for already-known CVEs.

--- a/src/main/java/dev/prasadgaikwad/vulnbench/ingest/ghsa/GhsaAdapter.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/ingest/ghsa/GhsaAdapter.java
@@ -11,8 +11,10 @@ import org.springframework.web.client.RestClient;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.springframework.web.client.HttpClientErrorException;
 
 /**
  * Fetches security advisories from GitHub's GraphQL API (GHSA database).
@@ -90,7 +92,7 @@ public class GhsaAdapter {
 
         while (hasMore) {
             try {
-                var variables = new java.util.HashMap<String, Object>();
+                var variables = new HashMap<String, Object>();
                 if (since != null)
                     variables.put("since", since.toString());
                 if (cursor != null)
@@ -122,7 +124,7 @@ public class GhsaAdapter {
                 cursor = advisories.pageInfo().endCursor();
                 log.debug("[GHSA] Fetched {} advisories so far", all.size());
 
-            } catch (org.springframework.web.client.HttpClientErrorException.Forbidden e) {
+            } catch (HttpClientErrorException.Forbidden e) {
                 if (e.getResponseBodyAsString().contains("rate limit exceeded")) {
                     log.warn("[GHSA] Rate limit exceeded. Authenticated requests have higher limits. Please check your GITHUB_TOKEN.");
                 } else {

--- a/src/main/java/dev/prasadgaikwad/vulnbench/ingest/nvd/NvdAdapter.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/ingest/nvd/NvdAdapter.java
@@ -14,7 +14,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 /**
  * Fetches CVEs from the NVD API 2.0.

--- a/src/main/java/dev/prasadgaikwad/vulnbench/ingest/nvd/NvdAdapter.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/ingest/nvd/NvdAdapter.java
@@ -11,6 +11,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -119,7 +120,7 @@ public class NvdAdapter {
     }
 
     private String formatForNvd(Instant instant) {
-        return NVD_DATE_FMT.format(instant.atZone(java.time.ZoneOffset.UTC));
+        return NVD_DATE_FMT.format(instant.atZone(ZoneOffset.UTC));
     }
 
     private VulnerabilityDto mapToDto(NvdResponse.NvdCve cve, String rawJson) {

--- a/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
@@ -3,6 +3,7 @@ package dev.prasadgaikwad.vulnbench.notification.slack;
 import com.slack.api.bolt.App;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -29,7 +30,7 @@ public class SlackService {
     public void sendMessage(String channel, String text) {
         try {
             MethodsClient client = slackApp.client();
-            var request = com.slack.api.methods.request.chat.ChatPostMessageRequest.builder()
+            var request = ChatPostMessageRequest.builder()
                     .channel(channel)
                     .text(text)
                     .build();

--- a/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
@@ -29,9 +29,11 @@ public class SlackService {
     public void sendMessage(String channel, String text) {
         try {
             MethodsClient client = slackApp.client();
-            var result = client.chatPostMessage(r -> r
+            var request = com.slack.api.methods.request.chat.ChatPostMessageRequest.builder()
                     .channel(channel)
-                    .text(text));
+                    .text(text)
+                    .build();
+            var result = client.chatPostMessage(request);
             if (result.isOk()) {
                 log.info("[Slack] Message sent successfully to {}", channel);
             } else {

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerTest.java
@@ -1,0 +1,74 @@
+package dev.prasadgaikwad.vulnbench.api;
+
+import dev.prasadgaikwad.vulnbench.batch.IngestService;
+import dev.prasadgaikwad.vulnbench.domain.IngestState;
+import dev.prasadgaikwad.vulnbench.notification.slack.SlackService;
+import dev.prasadgaikwad.vulnbench.repository.IngestStateRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AdminController.class)
+class AdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private IngestService ingestService;
+
+    @MockBean
+    private IngestStateRepository ingestStateRepo;
+
+    @MockBean
+    private SlackService slackService;
+
+    @Test
+    void testTriggerIngest() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/ingest/trigger"))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.message").exists());
+
+        // Note: runAsync makes verifying the exact call tricky in a fast mock test,
+        // but we at least know the endpoint returns 202.
+    }
+
+    @Test
+    void testGetStatus() throws Exception {
+        IngestState state = new IngestState();
+        state.setSourceName("NVD");
+        state.setStatus("SUCCESS");
+
+        when(ingestStateRepo.findAll()).thenReturn(List.of(state));
+
+        mockMvc.perform(get("/api/v1/admin/ingest/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].sourceName").value("NVD"))
+                .andExpect(jsonPath("$[0].status").value("SUCCESS"));
+    }
+
+    @Test
+    void testSlackTestMessage() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/ingest/slack/test")
+                        .param("channel", "C12345"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Test message sent to C12345"));
+
+        verify(slackService).sendTestMessage("C12345");
+    }
+
+    @Test
+    void testSlackTestMessage_FailsWithoutChannel() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/ingest/slack/test"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerTest.java
@@ -7,7 +7,7 @@ import dev.prasadgaikwad.vulnbench.repository.IngestStateRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -23,13 +23,13 @@ class AdminControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private IngestService ingestService;
 
-    @MockBean
+    @MockitoBean
     private IngestStateRepository ingestStateRepo;
 
-    @MockBean
+    @MockitoBean
     private SlackService slackService;
 
     @Test

--- a/src/test/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackServiceTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackServiceTest.java
@@ -1,0 +1,86 @@
+package dev.prasadgaikwad.vulnbench.notification.slack;
+
+import com.slack.api.bolt.App;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.response.chat.ChatPostMessageResponse;
+import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SlackServiceTest {
+
+    @Mock
+    private App slackApp;
+
+    @Mock
+    private MethodsClient methodsClient;
+
+    @InjectMocks
+    private SlackService slackService;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(slackApp.client()).thenReturn(methodsClient);
+    }
+
+    @Test
+    void testSendMessage_Success() throws IOException, SlackApiException {
+        ChatPostMessageResponse response = new ChatPostMessageResponse();
+        response.setOk(true);
+        when(methodsClient.chatPostMessage(any(ChatPostMessageRequest.class)))
+                .thenReturn(response);
+
+        slackService.sendMessage("C123", "Hello");
+
+        verify(methodsClient, times(1)).chatPostMessage(any(ChatPostMessageRequest.class));
+    }
+
+    @Test
+    void testSendMessage_Failure() throws IOException, SlackApiException {
+        ChatPostMessageResponse response = new ChatPostMessageResponse();
+        response.setOk(false);
+        response.setError("channel_not_found");
+        when(methodsClient.chatPostMessage(any(ChatPostMessageRequest.class)))
+                .thenReturn(response);
+
+        slackService.sendMessage("C123", "Hello");
+
+        // The method catches the error and logs it, we just verify the client was called
+        verify(methodsClient, times(1)).chatPostMessage(any(ChatPostMessageRequest.class));
+    }
+
+    @Test
+    void testSendMessage_Exception() throws IOException, SlackApiException {
+        when(methodsClient.chatPostMessage(any(ChatPostMessageRequest.class)))
+                .thenThrow(new IOException("Network error"));
+
+        slackService.sendMessage("C123", "Hello");
+
+        // The method catches the exception and logs it, no throw expected
+        verify(methodsClient, times(1)).chatPostMessage(any(ChatPostMessageRequest.class));
+    }
+
+    @Test
+    void testSendTestMessage() throws IOException, SlackApiException {
+        ChatPostMessageResponse response = new ChatPostMessageResponse();
+        response.setOk(true);
+        when(methodsClient.chatPostMessage(any(ChatPostMessageRequest.class)))
+                .thenReturn(response);
+
+        slackService.sendTestMessage("C123");
+
+        verify(methodsClient, times(1)).chatPostMessage(any(ChatPostMessageRequest.class));
+    }
+}


### PR DESCRIPTION
### Description
This pull request includes the final updates for Slice 2 (Slack Alerts Foundation):
- Added comprehensive JUnit tests for `AdminController` and `SlackService`.
- Replaced all fully qualified class names used inline with proper imports (e.g. in `GhsaAdapter`, `NvdAdapter`, `SlackService`).
- Replaced deprecated `@MockBean` with `@MockitoBean` from Spring Boot 3.4 test framework.
- Formatted and cleaned up code.

### Changes
- Created `AdminControllerTest` and `SlackServiceTest`.
- Refactored `GhsaAdapter` and `NvdAdapter` to remove inline `java.util.*`, `java.time.*`, etc.
- Refactored `SlackService` to utilize `ChatPostMessageRequest.builder()` pattern for testing ease.

All tests pass and the code is compliant with current standards.