### PR TITLE
feat: implement Watchlist Management API (Issue #2)

### DIFF
--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/WatchlistController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/WatchlistController.java
@@ -1,0 +1,57 @@
+package dev.prasadgaikwad.vulnbench.api;
+
+import dev.prasadgaikwad.vulnbench.api.dto.WatchlistRequest;
+import dev.prasadgaikwad.vulnbench.api.dto.WatchlistResponse;
+import dev.prasadgaikwad.vulnbench.service.WatchlistService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/watchlist")
+@RequiredArgsConstructor
+@Tag(name = "Watchlist", description = "Watchlist Management API")
+public class WatchlistController {
+
+    private final WatchlistService watchlistService;
+
+    @PostMapping
+    @Operation(summary = "Add a new package pattern to user's watchlist")
+    public ResponseEntity<WatchlistResponse> addWatchlistItem(@Valid @RequestBody WatchlistRequest request) {
+        log.info("[API] Request to add watchlist item for user '{}'", request.getUserId());
+        WatchlistResponse response = watchlistService.addWatchlistItem(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    @Operation(summary = "Get all watchlist items for a specific user")
+    public ResponseEntity<List<WatchlistResponse>> getWatchlistForUser(@RequestParam("userId") String userId) {
+        log.info("[API] Request to fetch watchlist for user '{}'", userId);
+        List<WatchlistResponse> watchlist = watchlistService.getWatchlistForUser(userId);
+        return ResponseEntity.ok(watchlist);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Delete a watchlist item by ID")
+    public ResponseEntity<Void> deleteWatchlistItem(@PathVariable("id") UUID id) {
+        log.info("[API] Request to delete watchlist item '{}'", id);
+        watchlistService.deleteWatchlistItem(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.warn("[API] Invalid watchlist request: {}", ex.getMessage());
+        return ResponseEntity.badRequest().body(Map.of("error", ex.getMessage()));
+    }
+}

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/WatchlistController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/WatchlistController.java
@@ -16,6 +16,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+/**
+ * REST Controller for managing user watchlists.
+ * Provides endpoints to add, list, and remove watched package patterns.
+ */
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/watchlist")
@@ -25,6 +29,12 @@ public class WatchlistController {
 
     private final WatchlistService watchlistService;
 
+    /**
+     * Adds a new package pattern to the specified user's watchlist.
+     *
+     * @param request the request body containing userId and packagePattern
+     * @return a {@link ResponseEntity} containing the created {@link WatchlistResponse}
+     */
     @PostMapping
     @Operation(summary = "Add a new package pattern to user's watchlist")
     public ResponseEntity<WatchlistResponse> addWatchlistItem(@Valid @RequestBody WatchlistRequest request) {
@@ -33,6 +43,12 @@ public class WatchlistController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    /**
+     * Retrieves all watchlist items for a specific user.
+     *
+     * @param userId the unique identifier of the user
+     * @return a {@link ResponseEntity} containing a list of {@link WatchlistResponse}
+     */
     @GetMapping
     @Operation(summary = "Get all watchlist items for a specific user")
     public ResponseEntity<List<WatchlistResponse>> getWatchlistForUser(@RequestParam("userId") String userId) {
@@ -41,6 +57,12 @@ public class WatchlistController {
         return ResponseEntity.ok(watchlist);
     }
 
+    /**
+     * Deletes a specific watchlist item by its unique ID.
+     *
+     * @param id the UUID of the watchlist item to delete
+     * @return a {@link ResponseEntity} with no content upon successful deletion
+     */
     @DeleteMapping("/{id}")
     @Operation(summary = "Delete a watchlist item by ID")
     public ResponseEntity<Void> deleteWatchlistItem(@PathVariable("id") UUID id) {
@@ -49,6 +71,12 @@ public class WatchlistController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * Exception handler for mapping {@link IllegalArgumentException} to a 400 Bad Request response.
+     *
+     * @param ex the exception thrown due to invalid arguments
+     * @return a {@link ResponseEntity} containing the error message map
+     */
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException ex) {
         log.warn("[API] Invalid watchlist request: {}", ex.getMessage());

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/dto/WatchlistRequest.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/dto/WatchlistRequest.java
@@ -1,0 +1,18 @@
+package dev.prasadgaikwad.vulnbench.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WatchlistRequest {
+    
+    @NotBlank(message = "userId is required")
+    private String userId;
+    
+    @NotBlank(message = "packagePattern is required")
+    private String packagePattern;
+}

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/dto/WatchlistRequest.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/dto/WatchlistRequest.java
@@ -5,6 +5,10 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+/**
+ * Data Transfer Object representing a request to add a new package pattern
+ * to a user's watchlist.
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/dto/WatchlistResponse.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/dto/WatchlistResponse.java
@@ -1,0 +1,21 @@
+package dev.prasadgaikwad.vulnbench.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class WatchlistResponse {
+    
+    private UUID id;
+    private String userId;
+    private String packagePattern;
+    private Instant createdAt;
+}

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/dto/WatchlistResponse.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/dto/WatchlistResponse.java
@@ -8,6 +8,10 @@ import lombok.NoArgsConstructor;
 import java.time.Instant;
 import java.util.UUID;
 
+/**
+ * Data Transfer Object representing a user's watchlist item in API responses.
+ * Contains the unique ID, the user ID, the watched package pattern, and the creation timestamp.
+ */
 @Data
 @Builder
 @NoArgsConstructor

--- a/src/main/java/dev/prasadgaikwad/vulnbench/domain/Watchlist.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/domain/Watchlist.java
@@ -7,6 +7,11 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.Instant;
 import java.util.UUID;
 
+/**
+ * Entity representing a user's subscription to a specific software package or pattern.
+ * This allows users to "watch" packages and receive alerts when new vulnerabilities
+ * affecting these packages are ingested.
+ */
 @Entity
 @Table(name = "watchlist", indexes = {
         @Index(name = "idx_watchlist_user_id", columnList = "user_id"),

--- a/src/main/java/dev/prasadgaikwad/vulnbench/domain/Watchlist.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/domain/Watchlist.java
@@ -1,0 +1,35 @@
+package dev.prasadgaikwad.vulnbench.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "watchlist", indexes = {
+        @Index(name = "idx_watchlist_user_id", columnList = "user_id"),
+        @Index(name = "idx_watchlist_package_pattern", columnList = "package_pattern")
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Watchlist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false, length = 100)
+    private String userId; // In a real system, this might link to a User entity. We use a String identifier for simplicity here.
+
+    @Column(name = "package_pattern", nullable = false, length = 255)
+    private String packagePattern; // e.g. "pkg:maven/org.springframework/*" or specific package name
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private Instant createdAt;
+}

--- a/src/main/java/dev/prasadgaikwad/vulnbench/repository/WatchlistRepository.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/repository/WatchlistRepository.java
@@ -7,6 +7,10 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Repository interface for managing {@link Watchlist} entities.
+ * Provides methods to query and verify user watchlist subscriptions.
+ */
 @Repository
 public interface WatchlistRepository extends JpaRepository<Watchlist, UUID> {
     

--- a/src/main/java/dev/prasadgaikwad/vulnbench/repository/WatchlistRepository.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/repository/WatchlistRepository.java
@@ -1,0 +1,16 @@
+package dev.prasadgaikwad.vulnbench.repository;
+
+import dev.prasadgaikwad.vulnbench.domain.Watchlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface WatchlistRepository extends JpaRepository<Watchlist, UUID> {
+    
+    List<Watchlist> findByUserId(String userId);
+    
+    boolean existsByUserIdAndPackagePattern(String userId, String packagePattern);
+}

--- a/src/main/java/dev/prasadgaikwad/vulnbench/service/WatchlistService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/service/WatchlistService.java
@@ -14,6 +14,12 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+/**
+ * Service responsible for managing user watchlists.
+ * Handles the business logic for adding, retrieving, and deleting package patterns
+ * that users wish to monitor for vulnerabilities. Also performs basic validation
+ * on the provided package patterns.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -74,6 +80,13 @@ public class WatchlistService {
         watchlistRepository.deleteById(id);
     }
 
+    /**
+     * Validates that the provided package pattern is not blank and possesses
+     * a valid basic structure or wildcards syntax that can be compiled as a regex.
+     *
+     * @param patternStr the package pattern string to validate
+     * @throws IllegalArgumentException if the pattern is blank or has invalid syntax
+     */
     private void validatePackagePattern(String patternStr) {
         if (patternStr == null || patternStr.isBlank()) {
             throw new IllegalArgumentException("Package pattern cannot be empty.");
@@ -91,6 +104,12 @@ public class WatchlistService {
         }
     }
 
+    /**
+     * Maps a {@link Watchlist} entity to a {@link WatchlistResponse} DTO.
+     *
+     * @param entity the Watchlist entity to map
+     * @return the corresponding WatchlistResponse DTO
+     */
     private WatchlistResponse mapToResponse(Watchlist entity) {
         return WatchlistResponse.builder()
                 .id(entity.getId())

--- a/src/main/java/dev/prasadgaikwad/vulnbench/service/WatchlistService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/service/WatchlistService.java
@@ -1,0 +1,102 @@
+package dev.prasadgaikwad.vulnbench.service;
+
+import dev.prasadgaikwad.vulnbench.api.dto.WatchlistRequest;
+import dev.prasadgaikwad.vulnbench.api.dto.WatchlistResponse;
+import dev.prasadgaikwad.vulnbench.domain.Watchlist;
+import dev.prasadgaikwad.vulnbench.repository.WatchlistRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WatchlistService {
+
+    private final WatchlistRepository watchlistRepository;
+
+    /**
+     * Adds a new package pattern to the user's watchlist.
+     *
+     * @param request the request containing userId and packagePattern
+     * @return the created Watchlist item mapped to a response DTO
+     */
+    @Transactional
+    public WatchlistResponse addWatchlistItem(WatchlistRequest request) {
+        log.info("[Watchlist] Adding package pattern '{}' for user '{}'", request.getPackagePattern(), request.getUserId());
+        
+        validatePackagePattern(request.getPackagePattern());
+
+        if (watchlistRepository.existsByUserIdAndPackagePattern(request.getUserId(), request.getPackagePattern())) {
+            throw new IllegalArgumentException("User is already watching this package pattern.");
+        }
+
+        Watchlist watchlist = Watchlist.builder()
+                .userId(request.getUserId())
+                .packagePattern(request.getPackagePattern())
+                .build();
+
+        Watchlist saved = watchlistRepository.save(watchlist);
+        return mapToResponse(saved);
+    }
+
+    /**
+     * Retrieves all watchlist items for a specific user.
+     *
+     * @param userId the user ID
+     * @return a list of WatchlistResponse items
+     */
+    @Transactional(readOnly = true)
+    public List<WatchlistResponse> getWatchlistForUser(String userId) {
+        log.debug("[Watchlist] Fetching watchlist for user '{}'", userId);
+        return watchlistRepository.findByUserId(userId).stream()
+                .map(this::mapToResponse)
+                .toList();
+    }
+
+    /**
+     * Deletes a watchlist item by its ID.
+     *
+     * @param id the UUID of the watchlist item
+     */
+    @Transactional
+    public void deleteWatchlistItem(UUID id) {
+        log.info("[Watchlist] Deleting watchlist item '{}'", id);
+        if (!watchlistRepository.existsById(id)) {
+            throw new IllegalArgumentException("Watchlist item not found");
+        }
+        watchlistRepository.deleteById(id);
+    }
+
+    private void validatePackagePattern(String patternStr) {
+        if (patternStr == null || patternStr.isBlank()) {
+            throw new IllegalArgumentException("Package pattern cannot be empty.");
+        }
+        
+        // Simple regex validation for Package URL (purl) or generic wildcard patterns
+        // Ensures it doesn't just contain malicious characters or completely invalid structure.
+        // E.g., pkg:maven/org.apache.* or *spring*
+        try {
+            // Check if it's a valid regex if they are using wildcard syntax by converting * to .*
+            String regex = patternStr.replace("*", ".*");
+            Pattern.compile(regex);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalArgumentException("Invalid package pattern syntax.");
+        }
+    }
+
+    private WatchlistResponse mapToResponse(Watchlist entity) {
+        return WatchlistResponse.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .packagePattern(entity.getPackagePattern())
+                .createdAt(entity.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/resources/db/migration/V7__create_watchlist.sql
+++ b/src/main/resources/db/migration/V7__create_watchlist.sql
@@ -1,0 +1,9 @@
+CREATE TABLE watchlist (
+    id UUID PRIMARY KEY,
+    user_id VARCHAR(100) NOT NULL,
+    package_pattern VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_watchlist_user_id ON watchlist(user_id);
+CREATE INDEX idx_watchlist_package_pattern ON watchlist(package_pattern);

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/WatchlistControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/WatchlistControllerTest.java
@@ -1,0 +1,85 @@
+package dev.prasadgaikwad.vulnbench.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.prasadgaikwad.vulnbench.api.dto.WatchlistRequest;
+import dev.prasadgaikwad.vulnbench.api.dto.WatchlistResponse;
+import dev.prasadgaikwad.vulnbench.service.WatchlistService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(WatchlistController.class)
+class WatchlistControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private WatchlistService watchlistService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testAddWatchlistItem_Success() throws Exception {
+        WatchlistRequest request = new WatchlistRequest("user1", "pkg1");
+        WatchlistResponse response = WatchlistResponse.builder()
+                .id(UUID.randomUUID())
+                .userId("user1")
+                .packagePattern("pkg1")
+                .build();
+
+        when(watchlistService.addWatchlistItem(any(WatchlistRequest.class))).thenReturn(response);
+
+        mockMvc.perform(post("/api/v1/watchlist")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.userId").value("user1"))
+                .andExpect(jsonPath("$.packagePattern").value("pkg1"));
+    }
+
+    @Test
+    void testAddWatchlistItem_InvalidRequest() throws Exception {
+        WatchlistRequest request = new WatchlistRequest("", ""); // Blank fields
+
+        mockMvc.perform(post("/api/v1/watchlist")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testGetWatchlistForUser() throws Exception {
+        WatchlistResponse response1 = WatchlistResponse.builder().id(UUID.randomUUID()).userId("user1").packagePattern("pkg1").build();
+        
+        when(watchlistService.getWatchlistForUser("user1")).thenReturn(List.of(response1));
+
+        mockMvc.perform(get("/api/v1/watchlist")
+                        .param("userId", "user1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].userId").value("user1"))
+                .andExpect(jsonPath("$[0].packagePattern").value("pkg1"));
+    }
+
+    @Test
+    void testDeleteWatchlistItem() throws Exception {
+        UUID id = UUID.randomUUID();
+        
+        mockMvc.perform(delete("/api/v1/watchlist/{id}", id))
+                .andExpect(status().isNoContent());
+
+        verify(watchlistService).deleteWatchlistItem(id);
+    }
+}

--- a/src/test/java/dev/prasadgaikwad/vulnbench/service/WatchlistServiceTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/service/WatchlistServiceTest.java
@@ -1,0 +1,100 @@
+package dev.prasadgaikwad.vulnbench.service;
+
+import dev.prasadgaikwad.vulnbench.api.dto.WatchlistRequest;
+import dev.prasadgaikwad.vulnbench.api.dto.WatchlistResponse;
+import dev.prasadgaikwad.vulnbench.domain.Watchlist;
+import dev.prasadgaikwad.vulnbench.repository.WatchlistRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class WatchlistServiceTest {
+
+    @Mock
+    private WatchlistRepository watchlistRepository;
+
+    @InjectMocks
+    private WatchlistService watchlistService;
+
+    @Test
+    void testAddWatchlistItem_Success() {
+        WatchlistRequest request = new WatchlistRequest("user1", "pkg:maven/org.springframework/*");
+        Watchlist saved = Watchlist.builder()
+                .id(UUID.randomUUID())
+                .userId("user1")
+                .packagePattern("pkg:maven/org.springframework/*")
+                .createdAt(Instant.now())
+                .build();
+
+        when(watchlistRepository.existsByUserIdAndPackagePattern("user1", "pkg:maven/org.springframework/*")).thenReturn(false);
+        when(watchlistRepository.save(any(Watchlist.class))).thenReturn(saved);
+
+        WatchlistResponse response = watchlistService.addWatchlistItem(request);
+
+        assertNotNull(response);
+        assertEquals("user1", response.getUserId());
+        assertEquals("pkg:maven/org.springframework/*", response.getPackagePattern());
+    }
+
+    @Test
+    void testAddWatchlistItem_AlreadyExists() {
+        WatchlistRequest request = new WatchlistRequest("user1", "pkg:maven/org.springframework/*");
+
+        when(watchlistRepository.existsByUserIdAndPackagePattern("user1", "pkg:maven/org.springframework/*")).thenReturn(true);
+
+        assertThrows(IllegalArgumentException.class, () -> watchlistService.addWatchlistItem(request));
+        verify(watchlistRepository, never()).save(any());
+    }
+
+    @Test
+    void testAddWatchlistItem_InvalidPattern() {
+        WatchlistRequest request = new WatchlistRequest("user1", "["); // Invalid regex pattern
+
+        assertThrows(IllegalArgumentException.class, () -> watchlistService.addWatchlistItem(request));
+        verify(watchlistRepository, never()).existsByUserIdAndPackagePattern(anyString(), anyString());
+    }
+
+    @Test
+    void testGetWatchlistForUser() {
+        Watchlist w1 = Watchlist.builder().id(UUID.randomUUID()).userId("user1").packagePattern("pkg1").build();
+        Watchlist w2 = Watchlist.builder().id(UUID.randomUUID()).userId("user1").packagePattern("pkg2").build();
+
+        when(watchlistRepository.findByUserId("user1")).thenReturn(List.of(w1, w2));
+
+        List<WatchlistResponse> responses = watchlistService.getWatchlistForUser("user1");
+        
+        assertEquals(2, responses.size());
+        assertEquals("pkg1", responses.get(0).getPackagePattern());
+        assertEquals("pkg2", responses.get(1).getPackagePattern());
+    }
+
+    @Test
+    void testDeleteWatchlistItem_Success() {
+        UUID id = UUID.randomUUID();
+        when(watchlistRepository.existsById(id)).thenReturn(true);
+
+        watchlistService.deleteWatchlistItem(id);
+
+        verify(watchlistRepository).deleteById(id);
+    }
+
+    @Test
+    void testDeleteWatchlistItem_NotFound() {
+        UUID id = UUID.randomUUID();
+        when(watchlistRepository.existsById(id)).thenReturn(false);
+
+        assertThrows(IllegalArgumentException.class, () -> watchlistService.deleteWatchlistItem(id));
+        verify(watchlistRepository, never()).deleteById(any());
+    }
+}


### PR DESCRIPTION
### Description
This pull request implements the Watchlist Management API as described in Issue #2. It enables users to watch specific software packages and receive alerts.

### Changes
- Created `Watchlist` JPA entity with fields `userId`, `packagePattern`, and `createdAt`.
- Created `V7__create_watchlist.sql` Flyway migration script for the new database table.
- Added `WatchlistRepository` to manage the entity persistence.
- Implemented `WatchlistService` featuring business logic and basic package pattern validation.
- Implemented `WatchlistController` exposing the following REST endpoints:
  - `POST /api/v1/watchlist`: Adds a new package pattern to the user's watchlist.
  - `GET /api/v1/watchlist`: Retrieves all watchlist items for a specific user.
  - `DELETE /api/v1/watchlist/{id}`: Deletes a watchlist item by its ID.
- Added comprehensive unit tests for `WatchlistService` and `WatchlistController`.

Closes #2