### PR TITLE
feat: Automated Slack Alerts for Watchlist Match (Issue #3)

### DIFF
--- a/src/main/java/dev/prasadgaikwad/vulnbench/batch/IngestService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/batch/IngestService.java
@@ -9,6 +9,7 @@ import dev.prasadgaikwad.vulnbench.ingest.normalize.VulnerabilityNormalizer;
 import dev.prasadgaikwad.vulnbench.ingest.nvd.NvdAdapter;
 import dev.prasadgaikwad.vulnbench.repository.IngestStateRepository;
 import dev.prasadgaikwad.vulnbench.repository.VulnerabilityRepository;
+import dev.prasadgaikwad.vulnbench.service.AlertService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -38,6 +39,7 @@ public class IngestService {
     private final VulnerabilityNormalizer normalizer;
     private final VulnerabilityRepository vulnRepo;
     private final IngestStateRepository ingestStateRepo;
+    private final AlertService alertService;
 
     @Value("${vulnbench.ingest.nvd.lookback-days:1}")
     private int lookbackDays;
@@ -51,14 +53,26 @@ public class IngestService {
         log.info("[Ingest] Starting full ingest cycle");
         Instant cycleStart = Instant.now();
 
-        int nvdCount = ingestSource("NVD", cycleStart);
-        int ghsaCount = ingestSource("GHSA", cycleStart);
+        List<Vulnerability> nvdVulns = ingestSource("NVD", cycleStart);
+        List<Vulnerability> ghsaVulns = ingestSource("GHSA", cycleStart);
 
-        log.info("[Ingest] Completed: NVD={}, GHSA={}", nvdCount, ghsaCount);
-        return new IngestResult(nvdCount, ghsaCount, cycleStart, Instant.now());
+        List<Vulnerability> allNewVulns = new java.util.ArrayList<>();
+        allNewVulns.addAll(nvdVulns);
+        allNewVulns.addAll(ghsaVulns);
+
+        if (!allNewVulns.isEmpty()) {
+            try {
+                alertService.processAlerts(allNewVulns);
+            } catch (Exception e) {
+                log.error("[Ingest] Failed to process alerts", e);
+            }
+        }
+
+        log.info("[Ingest] Completed: NVD={}, GHSA={}", nvdVulns.size(), ghsaVulns.size());
+        return new IngestResult(nvdVulns.size(), ghsaVulns.size(), cycleStart, Instant.now());
     }
 
-    private int ingestSource(String source, Instant cycleStart) {
+    private List<Vulnerability> ingestSource(String source, Instant cycleStart) {
         IngestState state = ingestStateRepo.findById(source)
                 .orElse(IngestState.builder().sourceName(source).build());
 
@@ -76,11 +90,11 @@ public class IngestService {
                 default -> List.of();
             };
 
-            int processed = processItems(dtos);
+            List<Vulnerability> processed = processItems(dtos);
 
             state.setStatus("SUCCESS");
             state.setLastIngestAt(cycleStart);
-            state.setLastCveCount(processed);
+            state.setLastCveCount(processed.size());
             state.setErrorMessage(null);
             ingestStateRepo.save(state);
 
@@ -91,13 +105,13 @@ public class IngestService {
             state.setStatus("FAILED");
             state.setErrorMessage(e.getMessage());
             ingestStateRepo.save(state);
-            return 0;
+            return List.of();
         }
     }
 
     @Transactional
-    public int processItems(List<VulnerabilityDto> dtos) {
-        int count = 0;
+    public List<Vulnerability> processItems(List<VulnerabilityDto> dtos) {
+        List<Vulnerability> newVulns = new java.util.ArrayList<>();
         for (VulnerabilityDto dto : dtos) {
             if (dto.cveId() == null)
                 continue;
@@ -110,13 +124,13 @@ public class IngestService {
                     Vulnerability vuln = normalizer.toEntity(dto);
                     vulnRepo.save(vuln);
                     dedupService.markKnown(dto.cveId());
-                    count++;
+                    newVulns.add(vuln);
                 }
             } catch (Exception e) {
                 log.warn("[Ingest] Failed to process {}: {}", dto.cveId(), e.getMessage());
             }
         }
-        return count;
+        return newVulns;
     }
 
     public record IngestResult(int nvdCount, int ghsaCount, Instant startedAt, Instant completedAt) {

--- a/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/notification/slack/SlackService.java
@@ -4,11 +4,16 @@ import com.slack.api.bolt.App;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.chat.ChatPostMessageRequest;
+import com.slack.api.model.block.Blocks;
+import com.slack.api.model.block.LayoutBlock;
+import com.slack.api.model.block.composition.BlockCompositions;
+import dev.prasadgaikwad.vulnbench.domain.Vulnerability;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * Service for interacting with Slack via the Bolt SDK.
@@ -53,5 +58,49 @@ public class SlackService {
     public void sendTestMessage(String channel) {
         String text = "🚀 *Vulnerability-Bench* is now connected to Slack!";
         sendMessage(channel, text);
+    }
+
+    /**
+     * Sends a formatted Block Kit alert about a new vulnerability matching a user's watchlist.
+     *
+     * @param channel               the target Slack channel or user ID
+     * @param vuln                  the matched Vulnerability
+     * @param matchedPackagePattern the watchlist pattern that triggered this alert
+     */
+    public void sendVulnerabilityAlert(String channel, Vulnerability vuln, String matchedPackagePattern) {
+        String cveId = vuln.getCveId() != null ? vuln.getCveId() : "Unknown CVE";
+        String title = vuln.getTitle() != null ? vuln.getTitle() : "New Vulnerability Detected";
+        String severity = vuln.getCvssV3Severity() != null ? vuln.getCvssV3Severity().name() : "UNKNOWN";
+        String score = vuln.getCvssV3Score() != null ? String.valueOf(vuln.getCvssV3Score()) : "N/A";
+        String nvdLink = "https://nvd.nist.gov/vuln/detail/" + cveId;
+
+        List<LayoutBlock> blocks = Blocks.asBlocks(
+                Blocks.header(h -> h.text(BlockCompositions.plainText(pt -> pt.text("🚨 Vulnerability Alert: " + cveId).emoji(true)))),
+                Blocks.section(s -> s.text(BlockCompositions.markdownText("*" + title + "*\n" +
+                        "A new vulnerability matching your watchlist pattern `" + matchedPackagePattern + "` has been ingested."))),
+                Blocks.divider(),
+                Blocks.section(s -> s.text(BlockCompositions.markdownText(
+                        "• *Severity:* " + severity + "\n" +
+                        "• *Score (CVSS v3):* " + score + "\n" +
+                        "• *Link:* <" + nvdLink + "|View on NVD>"
+                )))
+        );
+
+        try {
+            MethodsClient client = slackApp.client();
+            var request = ChatPostMessageRequest.builder()
+                    .channel(channel)
+                    .text("Vulnerability Alert: " + cveId) // Fallback for notifications
+                    .blocks(blocks)
+                    .build();
+            var result = client.chatPostMessage(request);
+            if (result.isOk()) {
+                log.info("[Slack] Alert sent successfully to {}", channel);
+            } else {
+                log.error("[Slack] Failed to send alert: {}", result.getError());
+            }
+        } catch (IOException | SlackApiException e) {
+            log.error("[Slack] Error while sending alert", e);
+        }
     }
 }

--- a/src/main/java/dev/prasadgaikwad/vulnbench/service/AlertService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/service/AlertService.java
@@ -1,0 +1,101 @@
+package dev.prasadgaikwad.vulnbench.service;
+
+import dev.prasadgaikwad.vulnbench.domain.AffectedPackage;
+import dev.prasadgaikwad.vulnbench.domain.Vulnerability;
+import dev.prasadgaikwad.vulnbench.domain.Watchlist;
+import dev.prasadgaikwad.vulnbench.notification.slack.SlackService;
+import dev.prasadgaikwad.vulnbench.repository.WatchlistRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Service responsible for evaluating newly ingested vulnerabilities against
+ * user watchlists and triggering alerts via Slack.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AlertService {
+
+    private final WatchlistRepository watchlistRepository;
+    private final SlackService slackService;
+
+    /**
+     * Processes a list of newly ingested vulnerabilities and sends Slack alerts
+     * to users whose watchlist patterns match any of the affected packages.
+     *
+     * @param newVulnerabilities the list of newly created Vulnerability records
+     */
+    @Transactional(readOnly = true)
+    public void processAlerts(List<Vulnerability> newVulnerabilities) {
+        if (newVulnerabilities == null || newVulnerabilities.isEmpty()) {
+            return;
+        }
+
+        List<Watchlist> watchlists = watchlistRepository.findAll();
+        if (watchlists.isEmpty()) {
+            return;
+        }
+
+        log.info("[AlertService] Processing alerts for {} new vulnerabilities", newVulnerabilities.size());
+
+        for (Vulnerability vuln : newVulnerabilities) {
+            Set<String> alertedUsersForVuln = new HashSet<>();
+
+            for (Watchlist watchlist : watchlists) {
+                // Prevent duplicate alerts to the same user for the same vulnerability
+                if (alertedUsersForVuln.contains(watchlist.getUserId())) {
+                    continue;
+                }
+
+                if (matches(vuln, watchlist)) {
+                    log.info("[AlertService] Matched vulnerability {} for user {} (pattern: {})", 
+                            vuln.getCveId(), watchlist.getUserId(), watchlist.getPackagePattern());
+                    
+                    slackService.sendVulnerabilityAlert(watchlist.getUserId(), vuln, watchlist.getPackagePattern());
+                    alertedUsersForVuln.add(watchlist.getUserId());
+                }
+            }
+        }
+    }
+
+    private boolean matches(Vulnerability vuln, Watchlist watchlist) {
+        String patternStr = watchlist.getPackagePattern();
+        if (patternStr == null || patternStr.isBlank()) {
+            return false;
+        }
+
+        // Convert wildcard to regex if needed (basic mapping)
+        String regexStr = patternStr.replace("*", ".*");
+        Pattern regex;
+        try {
+            regex = Pattern.compile(regexStr, Pattern.CASE_INSENSITIVE);
+        } catch (PatternSyntaxException e) {
+            log.warn("[AlertService] Invalid pattern syntax in watchlist {}: {}", watchlist.getId(), patternStr);
+            return false;
+        }
+
+        if (vuln.getAffectedPackages() == null) {
+            return false;
+        }
+
+        for (AffectedPackage pkg : vuln.getAffectedPackages()) {
+            if (pkg.getPurl() != null && regex.matcher(pkg.getPurl()).find()) {
+                return true;
+            }
+            if (pkg.getPackageName() != null && regex.matcher(pkg.getPackageName()).find()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/test/java/dev/prasadgaikwad/vulnbench/service/AlertServiceTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/service/AlertServiceTest.java
@@ -1,0 +1,129 @@
+package dev.prasadgaikwad.vulnbench.service;
+
+import dev.prasadgaikwad.vulnbench.domain.AffectedPackage;
+import dev.prasadgaikwad.vulnbench.domain.Vulnerability;
+import dev.prasadgaikwad.vulnbench.domain.Watchlist;
+import dev.prasadgaikwad.vulnbench.notification.slack.SlackService;
+import dev.prasadgaikwad.vulnbench.repository.WatchlistRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AlertServiceTest {
+
+    @Mock
+    private WatchlistRepository watchlistRepository;
+
+    @Mock
+    private SlackService slackService;
+
+    @InjectMocks
+    private AlertService alertService;
+
+    @Test
+    void testProcessAlerts_MatchedPackageName() {
+        Watchlist watchlist = Watchlist.builder()
+                .id(UUID.randomUUID())
+                .userId("slack_channel_1")
+                .packagePattern("spring-core")
+                .build();
+        when(watchlistRepository.findAll()).thenReturn(List.of(watchlist));
+
+        AffectedPackage affectedPackage = AffectedPackage.builder()
+                .packageName("spring-core")
+                .build();
+
+        Vulnerability vuln = Vulnerability.builder()
+                .cveId("CVE-2023-1234")
+                .affectedPackages(List.of(affectedPackage))
+                .build();
+
+        alertService.processAlerts(List.of(vuln));
+
+        verify(slackService).sendVulnerabilityAlert(eq("slack_channel_1"), eq(vuln), eq("spring-core"));
+    }
+
+    @Test
+    void testProcessAlerts_MatchedPurl() {
+        Watchlist watchlist = Watchlist.builder()
+                .id(UUID.randomUUID())
+                .userId("slack_channel_2")
+                .packagePattern("pkg:maven/org.apache.*")
+                .build();
+        when(watchlistRepository.findAll()).thenReturn(List.of(watchlist));
+
+        AffectedPackage affectedPackage = AffectedPackage.builder()
+                .purl("pkg:maven/org.apache.tomcat/tomcat-embed-core@9.0.41")
+                .build();
+
+        Vulnerability vuln = Vulnerability.builder()
+                .cveId("CVE-2023-5678")
+                .affectedPackages(List.of(affectedPackage))
+                .build();
+
+        alertService.processAlerts(List.of(vuln));
+
+        verify(slackService).sendVulnerabilityAlert(eq("slack_channel_2"), eq(vuln), eq("pkg:maven/org.apache.*"));
+    }
+
+    @Test
+    void testProcessAlerts_NoMatch() {
+        Watchlist watchlist = Watchlist.builder()
+                .id(UUID.randomUUID())
+                .userId("slack_channel_1")
+                .packagePattern("pkg:npm/express")
+                .build();
+        when(watchlistRepository.findAll()).thenReturn(List.of(watchlist));
+
+        AffectedPackage affectedPackage = AffectedPackage.builder()
+                .purl("pkg:maven/org.springframework/spring-core@5.3.0")
+                .build();
+
+        Vulnerability vuln = Vulnerability.builder()
+                .cveId("CVE-2023-0000")
+                .affectedPackages(List.of(affectedPackage))
+                .build();
+
+        alertService.processAlerts(List.of(vuln));
+
+        verify(slackService, never()).sendVulnerabilityAlert(anyString(), any(), anyString());
+    }
+
+    @Test
+    void testProcessAlerts_DuplicateAlertPrevention() {
+        // User has two watchlists that match the same vulnerability
+        Watchlist watchlist1 = Watchlist.builder()
+                .id(UUID.randomUUID())
+                .userId("userA")
+                .packagePattern("spring-*")
+                .build();
+        Watchlist watchlist2 = Watchlist.builder()
+                .id(UUID.randomUUID())
+                .userId("userA")
+                .packagePattern("*core")
+                .build();
+        when(watchlistRepository.findAll()).thenReturn(List.of(watchlist1, watchlist2));
+
+        AffectedPackage affectedPackage = AffectedPackage.builder()
+                .packageName("spring-core")
+                .build();
+
+        Vulnerability vuln = Vulnerability.builder()
+                .cveId("CVE-2023-1111")
+                .affectedPackages(List.of(affectedPackage))
+                .build();
+
+        alertService.processAlerts(List.of(vuln));
+
+        // Should only send 1 alert to userA despite matching 2 watchlists
+        verify(slackService, times(1)).sendVulnerabilityAlert(eq("userA"), eq(vuln), anyString());
+    }
+}


### PR DESCRIPTION
### Description
Implements Issue #3 — connects the ingestion pipeline to the Slack alert service to automatically notify users when new vulnerabilities match their watchlist patterns.

### Changes

#### New: `AlertService`
- Fetches all watchlists and evaluates each new `Vulnerability` ingested in the cycle.
- Matches against `packageName` and `purl` fields of `AffectedPackage` using the user's watchlist patterns (supporting `*` wildcards via regex conversion).
- Deduplicates alerts — a user only receives **one alert per vulnerability per ingest cycle**, even if multiple watchlist patterns match.

#### Updated: `SlackService`
- Added `sendVulnerabilityAlert()` method using the **Slack Block Kit** API for rich, high-quality notifications.
- Alert template includes:
  - 🚨 Header with CVE ID
  - Vulnerability title and matched watchlist pattern
  - Severity, CVSS v3 score, and direct link to NVD
- Cleaned up all fully qualified class names with proper imports.

#### Updated: `IngestService`
- Refactored `processItems()` to return `List<Vulnerability>` (newly saved records only).
- `ingestSource()` now accumulates new vulnerabilities and returns them.
- `runFullIngest()` collects all new vulnerabilities from all sources and passes them to `AlertService.processAlerts()` at the end of each cycle.

#### Tests: `AlertServiceTest`
- Tests covering: pattern match by package name, match by purl, no-match, and duplicate-alert prevention.

Closes #3