### PR TITLE
Fix Analytics Dashboard: Resolve column name mismatch in countBySource query #41

### DIFF
--- a/src/main/java/dev/prasadgaikwad/vulnbench/repository/VulnerabilityRepository.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/repository/VulnerabilityRepository.java
@@ -163,7 +163,7 @@ public interface VulnerabilityRepository extends JpaRepository<Vulnerability, UU
     @Query(value = """
             SELECT COUNT(DISTINCT vs.vulnerability_id)
             FROM vuln_source vs
-            WHERE vs.source_type = :sourceType
+            WHERE vs.source_name = :sourceType
             """, nativeQuery = true)
     long countBySource(@Param("sourceType") String sourceType);
 


### PR DESCRIPTION
### Summary of Changes
Resolved an HTTP 500 (Internal Server Error) occurring when attempting to load the Security Analytics Dashboard at `/dashboard/analytics`.

### Cause of the Issue
The `countBySource` method in [VulnerabilityRepository.java](file:///Users/prasadgaikwad/Code/antigravity/vulnerability-bench/src/main/java/dev/prasadgaikwad/vulnbench/repository/VulnerabilityRepository.java) executed a native PostgreSQL query filtering on the `vs.source_type` column of the `vuln_source` table:
```sql
SELECT COUNT(DISTINCT vs.vulnerability_id)
FROM vuln_source vs
WHERE vs.source_type = :sourceType
```
However, the database schema created in `V2__create_vuln_source.sql` maps the source field to the `source_name` column, not `source_type`. This mismatch resulted in a database `PSQLException` at runtime.

### Fix
Updated `countBySource` in `VulnerabilityRepository.java` to filter on the correct database column name: `source_name`.
```sql
SELECT COUNT(DISTINCT vs.vulnerability_id)
FROM vuln_source vs
WHERE vs.source_name = :sourceType
```

### Verification
1. Started the Spring Boot server.
2. Executed a test suite that dynamically requests `/dashboard/analytics` after completing form login authentication (with dynamic CSRF extraction).
3. Verified that the response status code is now **200 OK** and the HTML loads successfully.
4. Ran all Gradle integration and unit tests, and they successfully passed.

Closes #41.