### PR TITLE
Implement Export & Reporting Engine (CSV/PDF/JSON)

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Once the application is running, you can access the interactive API documentatio
 - [x] **Slice 4: Dashboard**: Web UI for triage and management (Thymeleaf + HTMX).
 - [x] **Slice 5: MCP Server**: Enable agentic AI to query vulnerability data.
 - [x] **Intelligence**: EPSS Integration & AI Exploitability Analysis.
-- [ ] **Slice 6: Export & Reporting**: PDF/CSV exports for security compliance.
+- [x] **Slice 6: Export & Reporting**: PDF/CSV/JSON exports for security compliance.
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 
     // Spring AI — OpenAI integration (artifact renamed in 1.0.0 GA)
     implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+
+    // Export and Reporting Dependencies
+    implementation 'com.github.librepdf:openpdf:1.3.43'
+    implementation 'org.apache.commons:commons-csv:1.11.0'
     
     compileOnly 'org.projectlombok:lombok:1.18.38'
     annotationProcessor 'org.projectlombok:lombok:1.18.38'

--- a/src/main/java/dev/prasadgaikwad/vulnbench/repository/VulnerabilityRepository.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/repository/VulnerabilityRepository.java
@@ -87,6 +87,18 @@ public interface VulnerabilityRepository extends JpaRepository<Vulnerability, UU
             @Param("ecosystem") String ecosystem,
             Pageable pageable);
 
+    @Query("""
+            SELECT v FROM Vulnerability v
+            WHERE (:severity IS NULL OR v.cvssV3Severity = :severity)
+              AND (:ecosystem IS NULL OR EXISTS (
+                      SELECT 1 FROM AffectedPackage ap
+                      WHERE ap.vulnerability = v AND ap.ecosystem = :ecosystem))
+            ORDER BY v.publishedAt DESC
+            """)
+    List<Vulnerability> findWithFiltersUnpaged(
+            @Param("severity") CvssV3Severity severity,
+            @Param("ecosystem") String ecosystem);
+
     /**
      * Performs a full-text search across vulnerability titles and descriptions using
      * PostgreSQL's native tsvector capabilities.
@@ -107,6 +119,14 @@ public interface VulnerabilityRepository extends JpaRepository<Vulnerability, UU
             """,
             nativeQuery = true)
     Page<Vulnerability> fullTextSearch(@Param("query") String query, Pageable pageable);
+
+    @Query(value = """
+            SELECT * FROM vulnerability
+            WHERE to_tsvector('english', coalesce(title,'') || ' ' || coalesce(description,''))
+                  @@ plainto_tsquery('english', :query)
+            """,
+            nativeQuery = true)
+    List<Vulnerability> fullTextSearchUnpaged(@Param("query") String query);
 
     /**
      * Returns CVE IDs for vulnerabilities affecting a specific package and ecosystem.

--- a/src/main/java/dev/prasadgaikwad/vulnbench/service/ExportService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/service/ExportService.java
@@ -1,0 +1,106 @@
+package dev.prasadgaikwad.vulnbench.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.lowagie.text.Document;
+import com.lowagie.text.DocumentException;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.PageSize;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfWriter;
+import dev.prasadgaikwad.vulnbench.domain.Vulnerability;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+public class ExportService {
+
+    private final ObjectMapper objectMapper;
+    private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(java.time.ZoneId.of("UTC"));
+
+    public ExportService() {
+        this.objectMapper = new ObjectMapper();
+        this.objectMapper.registerModule(new JavaTimeModule());
+    }
+
+    public byte[] exportToCsv(List<Vulnerability> vulnerabilities) {
+        StringWriter sw = new StringWriter();
+        try (CSVPrinter printer = new CSVPrinter(sw, CSVFormat.DEFAULT.builder().setHeader("CVE ID", "Title", "Severity", "CVSS V3", "EPSS", "Published At").build())) {
+            for (Vulnerability v : vulnerabilities) {
+                printer.printRecord(
+                        v.getCveId(),
+                        v.getTitle() != null ? v.getTitle() : "N/A",
+                        v.getCvssV3Severity() != null ? v.getCvssV3Severity().name() : "N/A",
+                        v.getCvssV3Score() != null ? v.getCvssV3Score().toString() : "N/A",
+                        v.getEpssScore() != null ? v.getEpssScore().toString() : "N/A",
+                        v.getPublishedAt() != null ? dateFormatter.format(v.getPublishedAt()) : "N/A"
+                );
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error generating CSV", e);
+        }
+        return sw.toString().getBytes();
+    }
+
+    public byte[] exportToPdf(List<Vulnerability> vulnerabilities) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            Document document = new Document(PageSize.A4.rotate());
+            PdfWriter.getInstance(document, baos);
+            document.open();
+
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 18);
+            Paragraph title = new Paragraph("Vulnerability Report", titleFont);
+            title.setAlignment(Paragraph.ALIGN_CENTER);
+            title.setSpacingAfter(20);
+            document.add(title);
+
+            PdfPTable table = new PdfPTable(6);
+            table.setWidthPercentage(100);
+            table.setWidths(new float[]{1.5f, 3.5f, 1f, 1f, 1f, 1.5f});
+
+            Font headerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 12);
+            String[] headers = {"CVE ID", "Title", "Severity", "CVSS V3", "EPSS", "Published At"};
+            for (String header : headers) {
+                PdfPCell cell = new PdfPCell(new Phrase(header, headerFont));
+                cell.setPadding(5);
+                table.addCell(cell);
+            }
+
+            Font rowFont = FontFactory.getFont(FontFactory.HELVETICA, 10);
+            for (Vulnerability v : vulnerabilities) {
+                table.addCell(new Phrase(v.getCveId(), rowFont));
+                table.addCell(new Phrase(v.getTitle() != null ? v.getTitle() : "N/A", rowFont));
+                table.addCell(new Phrase(v.getCvssV3Severity() != null ? v.getCvssV3Severity().name() : "N/A", rowFont));
+                table.addCell(new Phrase(v.getCvssV3Score() != null ? v.getCvssV3Score().toString() : "N/A", rowFont));
+                table.addCell(new Phrase(v.getEpssScore() != null ? v.getEpssScore().toString() : "N/A", rowFont));
+                table.addCell(new Phrase(v.getPublishedAt() != null ? dateFormatter.format(v.getPublishedAt()) : "N/A", rowFont));
+            }
+
+            document.add(table);
+            document.close();
+            return baos.toByteArray();
+        } catch (DocumentException | IOException e) {
+            throw new RuntimeException("Error generating PDF", e);
+        }
+    }
+
+    public byte[] exportToJson(List<Vulnerability> vulnerabilities) {
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsBytes(vulnerabilities);
+        } catch (IOException e) {
+            throw new RuntimeException("Error generating JSON", e);
+        }
+    }
+}

--- a/src/main/java/dev/prasadgaikwad/vulnbench/web/DashboardController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/web/DashboardController.java
@@ -31,6 +31,7 @@ public class DashboardController {
 
     private final VulnerabilityRepository vulnerabilityRepository;
     private final EnrichmentService enrichmentService;
+    private final dev.prasadgaikwad.vulnbench.service.ExportService exportService;
 
     /**
      * Main dashboard entry point. Renders the full page with filtered vulnerability results.
@@ -132,6 +133,51 @@ public class DashboardController {
 
         fetchVulnerabilities(severity, ecosystem, query, page, size, model);
         return "dashboard/fragments/vuln-table :: results";
+    }
+
+    @GetMapping("/export")
+    public org.springframework.http.ResponseEntity<byte[]> export(
+            @RequestParam(value = "severity", required = false) String severity,
+            @RequestParam(value = "ecosystem", required = false) String ecosystem,
+            @RequestParam(value = "q", required = false) String query,
+            @RequestParam(value = "format", defaultValue = "csv") String format) {
+
+        java.util.List<Vulnerability> vulnerabilities;
+        if (query != null && !query.isBlank()) {
+            vulnerabilities = vulnerabilityRepository.fullTextSearchUnpaged(query);
+        } else {
+            CvssV3Severity sev = null;
+            if (severity != null && !severity.isBlank() && !severity.equalsIgnoreCase("ALL")) {
+                try {
+                    sev = CvssV3Severity.valueOf(severity.toUpperCase());
+                } catch (IllegalArgumentException ignored) {}
+            }
+            String eco = (ecosystem != null && !ecosystem.isBlank() && !ecosystem.equalsIgnoreCase("ALL")) ? ecosystem : null;
+            vulnerabilities = vulnerabilityRepository.findWithFiltersUnpaged(sev, eco);
+        }
+
+        byte[] content;
+        String contentType;
+        String extension;
+        if ("pdf".equalsIgnoreCase(format)) {
+            content = exportService.exportToPdf(vulnerabilities);
+            contentType = "application/pdf";
+            extension = "pdf";
+        } else if ("json".equalsIgnoreCase(format)) {
+            content = exportService.exportToJson(vulnerabilities);
+            contentType = "application/json";
+            extension = "json";
+        } else {
+            content = exportService.exportToCsv(vulnerabilities);
+            contentType = "text/csv";
+            extension = "csv";
+        }
+
+        org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
+        headers.add(org.springframework.http.HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=vulnerability-export." + extension);
+        headers.add(org.springframework.http.HttpHeaders.CONTENT_TYPE, contentType);
+
+        return new org.springframework.http.ResponseEntity<>(content, headers, org.springframework.http.HttpStatus.OK);
     }
 
     /**

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -66,12 +66,30 @@
                 </select>
             </div>
             
+            <div class="input-group" style="align-items: flex-end;">
+                <label>Export</label>
+                <div style="display: flex; gap: 0.5rem;">
+                    <button type="button" class="btn btn-secondary" onclick="exportData('csv')">CSV</button>
+                    <button type="button" class="btn btn-secondary" onclick="exportData('pdf')">PDF</button>
+                    <button type="button" class="btn btn-secondary" onclick="exportData('json')">JSON</button>
+                </div>
+            </div>
+            
             <div style="display: flex; align-items: flex-end; padding-bottom: 0.6rem;">
                 <span class="htmx-indicator search-indicator" style="font-size: 0.8rem; color: var(--accent-primary);">
                     Refreshing...
                 </span>
             </div>
         </section>
+
+        <script>
+            function exportData(format) {
+                const q = document.getElementById('search').value;
+                const sev = document.getElementById('severity').value;
+                const eco = document.getElementById('ecosystem').value;
+                window.location.href = `/dashboard/export?q=${encodeURIComponent(q)}&severity=${encodeURIComponent(sev)}&ecosystem=${encodeURIComponent(eco)}&format=${format}`;
+            }
+        </script>
 
         <div class="table-container" id="vuln-table-body">
             <!-- Included via fragment initially -->

--- a/src/test/java/dev/prasadgaikwad/vulnbench/service/ExportServiceTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/service/ExportServiceTest.java
@@ -1,0 +1,85 @@
+package dev.prasadgaikwad.vulnbench.service;
+
+import dev.prasadgaikwad.vulnbench.domain.Vulnerability;
+import dev.prasadgaikwad.vulnbench.domain.CvssV3Severity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ExportServiceTest {
+
+    private ExportService exportService;
+
+    @BeforeEach
+    void setUp() {
+        exportService = new ExportService();
+    }
+
+    @Test
+    void testExportToCsv() {
+        List<Vulnerability> vulns = List.of(
+                Vulnerability.builder()
+                        .cveId("CVE-2023-1234")
+                        .title("Test Vuln")
+                        .cvssV3Severity(CvssV3Severity.CRITICAL)
+                        .cvssV3Score(9.8)
+                        .epssScore(0.5)
+                        .publishedAt(Instant.now())
+                        .build()
+        );
+
+        byte[] csvBytes = exportService.exportToCsv(vulns);
+        assertNotNull(csvBytes);
+        String csvContent = new String(csvBytes);
+        assertTrue(csvContent.contains("CVE ID,Title,Severity,CVSS V3,EPSS,Published At"));
+        assertTrue(csvContent.contains("CVE-2023-1234"));
+        assertTrue(csvContent.contains("CRITICAL"));
+    }
+
+    @Test
+    void testExportToPdf() {
+        List<Vulnerability> vulns = List.of(
+                Vulnerability.builder()
+                        .cveId("CVE-2023-5678")
+                        .title("PDF Vuln")
+                        .cvssV3Severity(CvssV3Severity.HIGH)
+                        .cvssV3Score(8.1)
+                        .epssScore(0.2)
+                        .publishedAt(Instant.now())
+                        .build()
+        );
+
+        byte[] pdfBytes = exportService.exportToPdf(vulns);
+        assertNotNull(pdfBytes);
+        assertTrue(pdfBytes.length > 0);
+        
+        // Basic PDF magic number check
+        assertTrue(pdfBytes[0] == 0x25); // %
+        assertTrue(pdfBytes[1] == 0x50); // P
+        assertTrue(pdfBytes[2] == 0x44); // D
+        assertTrue(pdfBytes[3] == 0x46); // F
+    }
+
+    @Test
+    void testExportToJson() {
+        List<Vulnerability> vulns = List.of(
+                Vulnerability.builder()
+                        .cveId("CVE-2023-9012")
+                        .title("JSON Vuln")
+                        .cvssV3Severity(CvssV3Severity.MEDIUM)
+                        .build()
+        );
+
+        byte[] jsonBytes = exportService.exportToJson(vulns);
+        assertNotNull(jsonBytes);
+        String jsonContent = new String(jsonBytes);
+        assertTrue(jsonContent.contains("CVE-2023-9012"));
+        assertTrue(jsonContent.contains("JSON Vuln"));
+        assertTrue(jsonContent.contains("MEDIUM"));
+    }
+}

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/DashboardControllerExportTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/DashboardControllerExportTest.java
@@ -1,0 +1,73 @@
+package dev.prasadgaikwad.vulnbench.web;
+
+import dev.prasadgaikwad.vulnbench.domain.Vulnerability;
+import dev.prasadgaikwad.vulnbench.repository.VulnerabilityRepository;
+import dev.prasadgaikwad.vulnbench.service.EnrichmentService;
+import dev.prasadgaikwad.vulnbench.service.ExportService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(DashboardController.class)
+class DashboardControllerExportTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private VulnerabilityRepository vulnerabilityRepository;
+
+    @MockitoBean
+    private EnrichmentService enrichmentService;
+
+    @MockitoBean
+    private ExportService exportService;
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void testExportCsv() throws Exception {
+        when(vulnerabilityRepository.findWithFiltersUnpaged(any(), any())).thenReturn(List.of(new Vulnerability()));
+        when(exportService.exportToCsv(any())).thenReturn("CSV CONTENT".getBytes());
+
+        mockMvc.perform(get("/dashboard/export?format=csv"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", "attachment; filename=vulnerability-export.csv"))
+                .andExpect(header().string("Content-Type", "text/csv"))
+                .andExpect(content().string("CSV CONTENT"));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void testExportPdf() throws Exception {
+        when(vulnerabilityRepository.findWithFiltersUnpaged(any(), any())).thenReturn(List.of(new Vulnerability()));
+        when(exportService.exportToPdf(any())).thenReturn(new byte[]{0x25, 0x50, 0x44, 0x46});
+
+        mockMvc.perform(get("/dashboard/export?format=pdf"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", "attachment; filename=vulnerability-export.pdf"))
+                .andExpect(header().string("Content-Type", "application/pdf"));
+    }
+
+    @Test
+    @WithMockUser(roles = "USER")
+    void testExportJson() throws Exception {
+        when(vulnerabilityRepository.findWithFiltersUnpaged(any(), any())).thenReturn(List.of(new Vulnerability()));
+        when(exportService.exportToJson(any())).thenReturn("[]".getBytes());
+
+        mockMvc.perform(get("/dashboard/export?format=json"))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Disposition", "attachment; filename=vulnerability-export.json"))
+                .andExpect(header().string("Content-Type", "application/json"))
+                .andExpect(content().string("[]"));
+    }
+}


### PR DESCRIPTION
Closes #18.

### Overview
This Pull Request introduces the **Export & Reporting Engine** to the dashboard, allowing security teams to download the currently filtered list of vulnerabilities in compliance-ready formats.

### Key Changes
1. **ExportService**: Uses `OpenPDF`, `Apache Commons CSV`, and `Jackson` to accurately generate structured export binaries.
2. **DashboardController**: Added a new `/export` endpoint which fetches an **unpaginated** set of filtered vulnerabilities for accurate and full datasets.
3. **UI Integration**: Added native HTML buttons configured via Javascript to pass the active dashboard filters directly to the download endpoint, ensuring a native browser download event without interfering with HTMX dynamic layouts or reloading the page.
4. **README.md**: Marked the roadmap task as completed.

### Testing
- Automated unit tests were added for `ExportServiceTest` and `DashboardControllerExportTest`. Tests are verified and passing locally.