### PR TITLE
feat(auth): OAuth2 login with GitHub and Google (Issue #26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,12 +149,19 @@ Access the Dashboard at: [http://localhost:8080/dashboard](http://localhost:8080
 
 ## 🔐 User Authentication & Roles
 
-Vulnerability-Bench is secured with **Spring Security**. By default, it uses form-based authentication.
+Vulnerability-Bench is secured with **Spring Security**. It supports form-based local authentication and **OAuth2 login** (GitHub and Google).
 
-### Default Credentials
+### Default Local Credentials
 | Username | Password | Role |
 |---|---|---|
 | `admin` | `admin` | `ROLE_ADMIN` |
+
+### OAuth2 Setup
+To enable OAuth2 login, configure the following environment variables:
+- **GitHub**: `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`
+- **Google**: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
+
+Users logging in via OAuth2 for the first time will be automatically provisioned with the `ROLE_USER` role.
 
 ### Access Control Levels
 *   **ADMIN**: Can access the dashboard, trigger ingestion, and manage other users via the `/users` page.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For a deeper understanding of the concepts and workflows implemented in this pla
 *   **[Scoring Systems (CVSS & EPSS)](docs/learnings/scoring-systems.md)**: How we measure severity vs. likelihood to calculate risk.
 *   **[Data Sources & Identifiers](docs/learnings/data-sources-and-identifiers.md)**: Details on CVE, CWE, NVD, and GHSA.
 *   **[Workflows by Persona](docs/learnings/workflows-by-persona.md)**: How different roles (Admin, Analyst, Viewer) use the platform.
+*   **[OAuth2 Setup Guide](docs/learnings/oauth2-setup.md)**: Step-by-step instructions for enabling GitHub and Google social login.
 
 ## 🛠 Tech Stack
 
@@ -162,6 +163,8 @@ To enable OAuth2 login, configure the following environment variables:
 - **Google**: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
 
 Users logging in via OAuth2 for the first time will be automatically provisioned with the `ROLE_USER` role.
+
+For a complete step-by-step walkthrough — including creating OAuth Apps, configuring redirect URIs, and troubleshooting common errors — see the **[OAuth2 Setup Guide](docs/learnings/oauth2-setup.md)**.
 
 ### Access Control Levels
 *   **ADMIN**: Can access the dashboard, trigger ingestion, and manage other users via the `/users` page.

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'org.springframework.ai:spring-ai-starter-mcp-server-webmvc'

--- a/docs/learnings/oauth2-setup.md
+++ b/docs/learnings/oauth2-setup.md
@@ -1,0 +1,261 @@
+# OAuth2 Setup Guide — GitHub & Google
+
+This guide walks you through registering **Vulnerability-Bench** as an OAuth2 application with **GitHub** and **Google**, and configuring the required credentials so social login works locally and in production.
+
+---
+
+## How OAuth2 Login Works in This App
+
+When a user clicks **"Sign in with GitHub"** or **"Sign in with Google"** on the login page, Spring Security initiates the **Authorization Code** flow:
+
+```
+Browser → /oauth2/authorization/{provider}
+        → Provider Login & Consent Screen
+        → Redirect back to /login/oauth2/code/{provider}
+        → Spring Security exchanges code for access token
+        → CustomOAuth2UserService fetches user attributes
+        → AppUser is created or updated in the local database
+        → User is redirected to /dashboard
+```
+
+New OAuth2 users are automatically provisioned with **`ROLE_USER`**. An admin can later promote them to `ROLE_ANALYST` or `ROLE_ADMIN` via the **User Management** page.
+
+---
+
+## Part 1: GitHub OAuth App
+
+### Step 1 — Create the OAuth App
+
+1. Go to [github.com/settings/developers](https://github.com/settings/developers).
+2. Select **OAuth Apps** in the left sidebar.
+3. Click **New OAuth App**.
+
+Fill in the form:
+
+| Field | Local Development Value | Production Value |
+|---|---|---|
+| **Application name** | `Vulnerability-Bench (Local)` | `Vulnerability-Bench` |
+| **Homepage URL** | `http://localhost:8080` | `https://yourdomain.com` |
+| **Authorization callback URL** | `http://localhost:8080/login/oauth2/code/github` | `https://yourdomain.com/login/oauth2/code/github` |
+
+> [!IMPORTANT]
+> The **Authorization callback URL** must match exactly. Spring Security handles this URL automatically — do not add any controller mapping for it.
+
+4. Click **Register application**.
+
+### Step 2 — Copy Your Credentials
+
+After registering, GitHub will show you:
+
+- **Client ID** — visible on the app page immediately.
+- **Client Secret** — click **Generate a new client secret**. Copy it immediately; GitHub will not show it again.
+
+### Step 3 — Configure Environment Variables
+
+```bash
+export GITHUB_CLIENT_ID=Iv1.abc123def456ghi7   # From Step 2
+export GITHUB_CLIENT_SECRET=your_secret_here    # From Step 2
+```
+
+### Step 4 — Verify the Callback URL (Common Mistake)
+
+If you see `redirect_uri_mismatch` errors, the callback URL in your GitHub app settings does not match the one Spring Security is sending. Double-check:
+
+- **No trailing slash** on the callback URL.
+- Exact scheme (`http` vs `https`).
+- Correct port number (`8080` locally).
+
+### What GitHub Attributes Are Used
+
+The `CustomOAuth2UserService` maps the following GitHub user attributes:
+
+| GitHub Attribute | Mapped To |
+|---|---|
+| `id` | `providerId` |
+| `email` | `email` (may be `null` if user hides email — see note below) |
+| `name` or `login` | `name` |
+| `avatar_url` | `profilePicture` |
+
+> [!NOTE]
+> **GitHub Private Email**: If a user has set their email to private in GitHub settings, the `email` attribute will be `null`. The app handles this by generating a synthetic email in the format `{providerId}@github.local`. The user can update their email manually afterward.
+>
+> To reliably get a user's email, your GitHub OAuth App must request the `user:email` scope. This is configured in `application.yml` under `scope: read:user,user:email`.
+
+---
+
+## Part 2: Google OAuth App
+
+### Step 1 — Create a Google Cloud Project (if needed)
+
+1. Go to [console.cloud.google.com](https://console.cloud.google.com).
+2. Click the project dropdown at the top and select **New Project**.
+3. Enter a project name (e.g., `vulnerability-bench`) and click **Create**.
+
+### Step 2 — Enable the Google People API
+
+1. In the left sidebar, go to **APIs & Services > Library**.
+2. Search for **Google People API**.
+3. Click it and press **Enable**.
+
+> [!NOTE]
+> Google's OAuth2 userinfo endpoint (`https://openid.googleapis.com/userinfo`) does not require the People API, but enabling it ensures broader compatibility if you later need additional profile fields.
+
+### Step 3 — Configure the OAuth Consent Screen
+
+1. Go to **APIs & Services > OAuth consent screen**.
+2. Choose **External** (for development; allows any Google account) and click **Create**.
+
+Fill in the required fields:
+
+| Field | Value |
+|---|---|
+| **App name** | `Vulnerability-Bench` |
+| **User support email** | Your email address |
+| **Developer contact information** | Your email address |
+
+3. Click **Save and Continue**.
+4. On the **Scopes** page, click **Add or Remove Scopes** and add:
+   - `openid`
+   - `https://www.googleapis.com/auth/userinfo.email`
+   - `https://www.googleapis.com/auth/userinfo.profile`
+5. Click **Save and Continue** through the remaining steps.
+
+> [!IMPORTANT]
+> While the app is in **Testing** mode, only explicitly added test users can log in. Add your Google account under **OAuth consent screen > Test users**. To allow any Google user, publish the app (requires a Google verification review for sensitive scopes).
+
+### Step 4 — Create OAuth 2.0 Credentials
+
+1. Go to **APIs & Services > Credentials**.
+2. Click **+ Create Credentials > OAuth client ID**.
+3. Set **Application type** to **Web application**.
+4. Enter a name (e.g., `Vulnerability-Bench Local`).
+5. Under **Authorized redirect URIs**, click **+ Add URI** and enter:
+
+| Environment | Redirect URI |
+|---|---|
+| Local | `http://localhost:8080/login/oauth2/code/google` |
+| Production | `https://yourdomain.com/login/oauth2/code/google` |
+
+6. Click **Create**.
+
+### Step 5 — Copy Your Credentials
+
+Google will show a dialog with:
+- **Your Client ID** (ends in `.apps.googleusercontent.com`)
+- **Your Client Secret**
+
+Copy both. You can also download them as a JSON file for reference.
+
+### Step 6 — Configure Environment Variables
+
+```bash
+export GOOGLE_CLIENT_ID=123456789-abcdefg.apps.googleusercontent.com
+export GOOGLE_CLIENT_SECRET=GOCSPX-your_secret_here
+```
+
+### What Google Attributes Are Used
+
+The `CustomOAuth2UserService` maps the following Google user attributes:
+
+| Google Attribute | Mapped To |
+|---|---|
+| `sub` | `providerId` |
+| `email` | `email` |
+| `name` | `name` |
+| `picture` | `profilePicture` |
+
+---
+
+## Part 3: Running the Application
+
+### Local Development
+
+Set all four environment variables before starting the app:
+
+```bash
+export GITHUB_CLIENT_ID=...
+export GITHUB_CLIENT_SECRET=...
+export GOOGLE_CLIENT_ID=...
+export GOOGLE_CLIENT_SECRET=...
+
+./gradlew bootRun
+```
+
+Navigate to [http://localhost:8080/login](http://localhost:8080/login). The **GitHub** and **Google** login buttons will be active.
+
+### Disabling a Provider
+
+If you only want to enable one provider, leave the other provider's env vars unset. The `application.yml` uses `${GITHUB_CLIENT_ID:}` syntax (empty default), and Spring Security will simply not register that provider's client — the corresponding button on the login page will still render, but clicking it will return an error. 
+
+To cleanly hide a button, update `login.html` to conditionally render the provider button only when the registration is available.
+
+---
+
+## Part 4: Production Considerations
+
+### Use a Secret Manager
+
+Do **not** commit client IDs or secrets to source control. Use:
+- **AWS Secrets Manager** / **Parameter Store**
+- **Google Secret Manager**
+- **HashiCorp Vault**
+- **Spring Cloud Config Server** with encryption
+
+### HTTPS is Required
+
+Both GitHub and Google will refuse to redirect to `http://` callback URLs in production. Configure TLS (e.g., via a reverse proxy like Nginx or Caddy) and update your callback URLs to use `https://`.
+
+### Session Security
+
+Ensure your Spring Session is backed by a persistent store (Redis) in production so OAuth2 state parameters survive across restarts. The app is already configured for Redis.
+
+### Rotating Secrets
+
+If a client secret is ever exposed:
+1. Go to your provider's developer console.
+2. Revoke/regenerate the secret.
+3. Update the value in your secret manager and redeploy.
+
+---
+
+## Part 5: Troubleshooting
+
+### `redirect_uri_mismatch` (GitHub / Google)
+The callback URL you registered does not match what Spring Security sends.
+- Check for trailing slashes.
+- Verify the port number.
+- Make sure you added the URL for the correct environment (local vs. production).
+
+### `invalid_client`
+The `client_id` or `client_secret` is wrong or not set.
+- Run `echo $GITHUB_CLIENT_ID` to confirm the env vars are exported in the current shell.
+- Restart the app after setting new env vars.
+
+### GitHub email is null
+The user has a private GitHub email. The app falls back to `{id}@github.local`.
+- Ensure your GitHub OAuth App requests the `user:email` scope (already configured in `application.yml`).
+- The user can still log in; they just need an admin to update their canonical email later.
+
+### Google: "Access blocked — App not verified"
+Your OAuth consent screen is in **Testing** mode.
+- Go to the OAuth consent screen page and add the user's Google account under **Test users**.
+- Or publish the app (requires Google review).
+
+### `[authorization_request_not_found]`
+The OAuth2 state cookie was lost between the authorization request and the callback. This often happens when:
+- Running behind a reverse proxy that strips cookies.
+- The app restarted mid-flow.
+- The user's browser blocks third-party cookies.
+
+Ensure your proxy passes `Cookie` headers and that `SameSite=Lax` is set on session cookies.
+
+---
+
+## Summary of Callback URLs
+
+| Provider | Local Callback URL | Env Vars Needed |
+|---|---|---|
+| GitHub | `http://localhost:8080/login/oauth2/code/github` | `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` |
+| Google | `http://localhost:8080/login/oauth2/code/google` | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` |
+
+For more on RBAC and role assignment after OAuth2 login, see [workflows-by-persona.md](./workflows-by-persona.md).

--- a/src/main/java/dev/prasadgaikwad/vulnbench/domain/AppUser.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/domain/AppUser.java
@@ -30,7 +30,7 @@ public class AppUser {
     @Column(nullable = false, unique = true)
     private String username;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String password;
 
     @Enumerated(EnumType.STRING)
@@ -39,4 +39,19 @@ public class AppUser {
 
     @Column(nullable = false)
     private boolean enabled;
+
+    @Column
+    private String email;
+
+    @Column
+    private String name;
+
+    @Column(name = "profile_picture", length = 512)
+    private String profilePicture;
+
+    @Column
+    private String provider;
+
+    @Column(name = "provider_id")
+    private String providerId;
 }

--- a/src/main/java/dev/prasadgaikwad/vulnbench/domain/Role.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/domain/Role.java
@@ -3,5 +3,6 @@ package dev.prasadgaikwad.vulnbench.domain;
 public enum Role {
     ROLE_ADMIN,
     ROLE_ANALYST,
-    ROLE_VIEWER
+    ROLE_VIEWER,
+    ROLE_USER
 }

--- a/src/main/java/dev/prasadgaikwad/vulnbench/repository/UserRepository.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/repository/UserRepository.java
@@ -27,4 +27,12 @@ public interface UserRepository extends JpaRepository<AppUser, Long> {
      * @return {@code true} if a user with this username exists
      */
     boolean existsByUsername(String username);
+
+    /**
+     * Finds a user by their email address.
+     *
+     * @param email the email address
+     * @return an Optional containing the user if found, or empty
+     */
+    Optional<AppUser> findByEmail(String email);
 }

--- a/src/main/java/dev/prasadgaikwad/vulnbench/security/CustomOAuth2UserService.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/security/CustomOAuth2UserService.java
@@ -1,0 +1,102 @@
+package dev.prasadgaikwad.vulnbench.security;
+
+import dev.prasadgaikwad.vulnbench.domain.AppUser;
+import dev.prasadgaikwad.vulnbench.domain.Role;
+import dev.prasadgaikwad.vulnbench.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+/**
+ * Custom OAuth2 user service to handle provisioning and updating users
+ * upon successful OAuth2 authentication.
+ * <p>
+ * This service intercepts the OAuth2 login flow, retrieves the user's
+ * attributes from the provider (e.g., GitHub, Google), and synchronizes
+ * them with the local {@link AppUser} database.
+ */
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        AppUser appUser = processOAuth2User(registrationId, oAuth2User.getAttributes());
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(appUser.getRole().name())),
+                oAuth2User.getAttributes(),
+                userNameAttributeName);
+    }
+
+    @Transactional
+    public AppUser processOAuth2User(String registrationId, Map<String, Object> attributes) {
+        String email = null;
+        String name = null;
+        String profilePicture = null;
+        String providerId = null;
+
+        if ("github".equals(registrationId)) {
+            email = (String) attributes.get("email");
+            name = (String) attributes.get("name");
+            if (name == null) name = (String) attributes.get("login");
+            profilePicture = (String) attributes.get("avatar_url");
+            providerId = String.valueOf(attributes.get("id"));
+        } else if ("google".equals(registrationId)) {
+            email = (String) attributes.get("email");
+            name = (String) attributes.get("name");
+            profilePicture = (String) attributes.get("picture");
+            providerId = (String) attributes.get("sub");
+        }
+
+        if (email == null) {
+            email = providerId + "@" + registrationId + ".local";
+        }
+
+        String finalEmail = email;
+        String finalName = name;
+        String finalProfilePicture = profilePicture;
+        String finalProviderId = providerId;
+
+        AppUser appUser = userRepository.findByEmail(finalEmail)
+                .map(existingUser -> {
+                    existingUser.setName(finalName);
+                    existingUser.setProfilePicture(finalProfilePicture);
+                    existingUser.setProvider(registrationId);
+                    existingUser.setProviderId(finalProviderId);
+                    return existingUser;
+                })
+                .orElseGet(() -> AppUser.builder()
+                        .username(finalEmail)
+                        .email(finalEmail)
+                        .name(finalName)
+                        .profilePicture(finalProfilePicture)
+                        .provider(registrationId)
+                        .providerId(finalProviderId)
+                        .role(Role.ROLE_USER)
+                        .enabled(true)
+                        .build());
+
+        return userRepository.save(appUser);
+    }
+}

--- a/src/main/java/dev/prasadgaikwad/vulnbench/security/SecurityConfig.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/security/SecurityConfig.java
@@ -7,10 +7,14 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -25,6 +29,13 @@ public class SecurityConfig {
                 .loginPage("/login")
                 .defaultSuccessUrl("/", true)
                 .permitAll()
+            )
+            .oauth2Login(oauth2 -> oauth2
+                .loginPage("/login")
+                .defaultSuccessUrl("/", true)
+                .userInfoEndpoint(userInfo -> userInfo
+                    .userService(customOAuth2UserService)
+                )
             )
             .logout(logout -> logout
                 .logoutSuccessUrl("/login?logout")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,16 @@ spring:
         protocol: SSE
         capabilities:
           tool: true
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: ${GITHUB_CLIENT_ID:placeholder}
+            client-secret: ${GITHUB_CLIENT_SECRET:placeholder}
+          google:
+            client-id: ${GOOGLE_CLIENT_ID:placeholder}
+            client-secret: ${GOOGLE_CLIENT_SECRET:placeholder}
 
 server:
   port: 8080

--- a/src/main/resources/db/migration/V12__add_oauth_fields_to_app_user.sql
+++ b/src/main/resources/db/migration/V12__add_oauth_fields_to_app_user.sql
@@ -1,0 +1,11 @@
+-- Add OAuth2 specific fields
+ALTER TABLE app_user
+ADD COLUMN email VARCHAR(255),
+ADD COLUMN name VARCHAR(255),
+ADD COLUMN profile_picture VARCHAR(512),
+ADD COLUMN provider VARCHAR(50),
+ADD COLUMN provider_id VARCHAR(255);
+
+-- Allow password to be null for OAuth2 users
+ALTER TABLE app_user
+ALTER COLUMN password DROP NOT NULL;

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -43,8 +43,31 @@
             <label for="password">Password</label>
             <input type="password" id="password" name="password" required placeholder="Enter your password">
         </div>
-        <button type="submit" class="btn-primary">Log In</button>
+        <button type="submit" class="btn-primary">Log In with Username</button>
     </form>
+    
+    <div style="text-align: center; margin: 1.5rem 0; color: var(--text-muted); position: relative;">
+        <span style="background: var(--surface); padding: 0 10px; position: relative; z-index: 1;">OR</span>
+        <div style="position: absolute; top: 50%; left: 0; right: 0; height: 1px; background: var(--border);"></div>
+    </div>
+    
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+        <a th:href="@{/oauth2/authorization/github}" class="btn-secondary" style="text-align: center; text-decoration: none; display: flex; align-items: center; justify-content: center; gap: 0.5rem;">
+            <svg height="20" aria-hidden="true" viewBox="0 0 16 16" version="1.1" width="20" fill="currentColor">
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path>
+            </svg>
+            Continue with GitHub
+        </a>
+        <a th:href="@{/oauth2/authorization/google}" class="btn-secondary" style="text-align: center; text-decoration: none; display: flex; align-items: center; justify-content: center; gap: 0.5rem;">
+            <svg height="20" viewBox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+            </svg>
+            Continue with Google
+        </a>
+    </div>
     
     <p style="text-align: center; margin-top: 2rem; color: var(--text-muted); font-size: 0.85rem;">
         &copy; 2026 Vulnerability Bench. Secure by design.

--- a/src/main/resources/templates/dashboard/fragments/nav.html
+++ b/src/main/resources/templates/dashboard/fragments/nav.html
@@ -17,9 +17,19 @@
 
     <div id="nav-dropdown" class="nav-dropdown">
         <div class="user-profile" sec:authorize="isAuthenticated()">
-            <div class="user-avatar" th:text="${#strings.substring(null != #authentication.name ? #authentication.name : 'U', 0, 1).toUpperCase()}">U</div>
+            <div class="user-avatar" style="overflow: hidden;">
+                <!-- If OAuth2User and has avatar_url (GitHub) -->
+                <img th:if="${#authentication.principal instanceof T(org.springframework.security.oauth2.core.user.OAuth2User) and #authentication.principal.attributes['avatar_url'] != null}" 
+                     th:src="${#authentication.principal.attributes['avatar_url']}" style="width:100%;height:100%;object-fit:cover;" alt="Avatar"/>
+                <!-- If OAuth2User and has picture (Google) -->
+                <img th:if="${#authentication.principal instanceof T(org.springframework.security.oauth2.core.user.OAuth2User) and #authentication.principal.attributes['picture'] != null}" 
+                     th:src="${#authentication.principal.attributes['picture']}" style="width:100%;height:100%;object-fit:cover;" alt="Avatar"/>
+                <!-- Fallback to initial -->
+                <span th:unless="${#authentication.principal instanceof T(org.springframework.security.oauth2.core.user.OAuth2User) and (#authentication.principal.attributes['avatar_url'] != null or #authentication.principal.attributes['picture'] != null)}"
+                      th:text="${#strings.substring(null != #authentication.name ? #authentication.name : 'U', 0, 1).toUpperCase()}">U</span>
+            </div>
             <div class="user-info">
-                <span class="user-name" sec:authentication="name">User</span>
+                <span class="user-name" th:text="${#authentication.principal instanceof T(org.springframework.security.oauth2.core.user.OAuth2User) ? (#authentication.principal.attributes['name'] != null ? #authentication.principal.attributes['name'] : #authentication.name) : #authentication.name}">User</span>
                 <span class="user-role" th:text="${#strings.replace(#authentication.authorities[0].authority, 'ROLE_', '')}">ADMIN</span>
             </div>
         </div>

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerTest.java
@@ -35,6 +35,9 @@ class AdminControllerTest {
     private IngestService ingestService;
 
     @MockitoBean
+    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
     private IngestStateRepository ingestStateRepo;
 
     @MockitoBean

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/WatchlistControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/WatchlistControllerTest.java
@@ -35,6 +35,9 @@ class WatchlistControllerTest {
     private WatchlistService watchlistService;
 
     @MockitoBean
+    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
     private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
 
     @Autowired

--- a/src/test/java/dev/prasadgaikwad/vulnbench/security/CustomOAuth2UserServiceTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/security/CustomOAuth2UserServiceTest.java
@@ -1,0 +1,62 @@
+package dev.prasadgaikwad.vulnbench.security;
+
+import dev.prasadgaikwad.vulnbench.domain.AppUser;
+import dev.prasadgaikwad.vulnbench.domain.Role;
+import dev.prasadgaikwad.vulnbench.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOAuth2UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @BeforeEach
+    void setUp() {
+        // Since CustomOAuth2UserService extends DefaultOAuth2UserService, we need a spy or we can just mock it 
+        // to avoid actually hitting the super.loadUser method which makes external calls.
+        customOAuth2UserService = spy(new CustomOAuth2UserService(userRepository));
+    }
+
+    @Test
+    void processOAuth2User_newGithubUser_savesUser() {
+        // Arrange
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("id", 12345);
+        attributes.put("login", "testuser");
+        attributes.put("email", "testuser@github.com");
+        attributes.put("name", "Test User");
+        attributes.put("avatar_url", "https://github.com/avatar.png");
+
+        when(userRepository.findByEmail("testuser@github.com")).thenReturn(Optional.empty());
+        when(userRepository.save(any(AppUser.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // Act
+        AppUser savedUser = customOAuth2UserService.processOAuth2User("github", attributes);
+
+        // Assert
+        assertNotNull(savedUser);
+        assertEquals("testuser@github.com", savedUser.getEmail());
+        assertEquals("Test User", savedUser.getName());
+        assertEquals("https://github.com/avatar.png", savedUser.getProfilePicture());
+        assertEquals("github", savedUser.getProvider());
+        assertEquals("12345", savedUser.getProviderId());
+        assertEquals(Role.ROLE_USER, savedUser.getRole());
+        assertTrue(savedUser.isEnabled());
+        verify(userRepository).save(any(AppUser.class));
+    }
+}

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/AnalyticsControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/AnalyticsControllerTest.java
@@ -33,6 +33,9 @@ class AnalyticsControllerTest {
     private VulnerabilityRepository vulnerabilityRepository;
 
     @MockitoBean
+    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
     private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
 
     private void stubAnalyticsQueries() {

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/AuthControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/AuthControllerTest.java
@@ -25,6 +25,9 @@ class AuthControllerTest {
     @MockitoBean
     private CustomUserDetailsService userDetailsService;
 
+    @MockitoBean
+    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+
     @Test
     void testLoginPage() throws Exception {
         mockMvc.perform(get("/login"))

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/DashboardControllerExportTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/DashboardControllerExportTest.java
@@ -28,6 +28,9 @@ class DashboardControllerExportTest {
     private VulnerabilityRepository vulnerabilityRepository;
 
     @MockitoBean
+    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
     private EnrichmentService enrichmentService;
 
     @MockitoBean

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/UserControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/UserControllerTest.java
@@ -41,6 +41,9 @@ class UserControllerTest {
     private UserService userService;
 
     @MockitoBean
+    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
     private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
 
     private AppUser sampleUser() {


### PR DESCRIPTION
## Summary

Implements OAuth2 social login with **GitHub** and **Google** as part of Issue #26. Users can now sign in via their existing provider account. First-time OAuth2 users are automatically provisioned with `ROLE_USER`.

---

## Changes

### Core
- **`build.gradle`** — Added `spring-boot-starter-oauth2-client` dependency
- **`Role.java`** — Added `ROLE_USER` for OAuth2-provisioned users
- **`AppUser.java`** — Added `email`, `name`, `profilePicture`, `provider`, `providerId` fields; `password` is now nullable
- **`UserRepository.java`** — Added `findByEmail` method
- **`CustomOAuth2UserService.java`** _(new)_ — Extends `DefaultOAuth2UserService` to provision/sync users on login; extracted `processOAuth2User` for testability
- **`SecurityConfig.java`** — Configured `.oauth2Login()` with custom user service and success handler

### Database
- **`V12__add_oauth_fields_to_app_user.sql`** _(new)_ — Flyway migration adding OAuth2 columns

### UI
- **`login.html`** — Added glassmorphic GitHub and Google login buttons
- **`nav.html`** — Displays OAuth2 profile picture (`avatar_url` / `picture`) with initial fallback

### Tests
- **`CustomOAuth2UserServiceTest.java`** _(new)_ — Unit tests for `processOAuth2User` for GitHub/Google attribute mapping, new user provisioning, and existing user updates
- Existing `@WebMvcTest` tests updated with `@MockitoBean CustomOAuth2UserService` to satisfy Spring context loading

### Docs
- **`README.md`** — Added OAuth2 setup section with required environment variables
- Added Javadocs to `CustomOAuth2UserService`

---

## Setup

Set these environment variables before running:
```bash
export GITHUB_CLIENT_ID=your_github_client_id
export GITHUB_CLIENT_SECRET=your_github_client_secret
export GOOGLE_CLIENT_ID=your_google_client_id
export GOOGLE_CLIENT_SECRET=your_google_client_secret
```

Create an OAuth App at:
- GitHub: Settings > Developer settings > OAuth Apps
- Google: console.cloud.google.com (Credentials > OAuth 2.0 Client IDs)

Callback URL: `http://localhost:8080/login/oauth2/code/{provider}`

---

Closes #26