### PR TITLE
Add API security tests and page-size cap test (issue #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,4 +242,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ### 2026-05-21 — Tests
 - Implemented additional API security and endpoint tests (issue #45): expanded vulnerability search tests and CSRF coverage for enrichment endpoints. See tests under `src/test/java/dev/prasadgaikwad/vulnbench/api`.
+- Added a test to verify the vulnerabilities list endpoint caps requested page sizes to 100 to avoid excessive query load.
+
+Pull request: https://github.com/prasadgaikwad/vulnerability-bench/pull/50
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ### 2026-05-21 — Tests
 - Implemented additional API security and endpoint tests (issue #45): expanded vulnerability search tests and CSRF coverage for enrichment endpoints. See tests under `src/test/java/dev/prasadgaikwad/vulnbench/api`.
 - Added a test to verify the vulnerabilities list endpoint caps requested page sizes to 100 to avoid excessive query load.
-
-Pull request: https://github.com/prasadgaikwad/vulnerability-bench/pull/50
-

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityController.java
@@ -20,6 +20,15 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * REST controller exposing the core vulnerability APIs: listing, searching,
+ * and triggering AI enrichment for vulnerability records.
+ *
+ * <p>Endpoints are versioned under <code>/api/v1/vulnerabilities</code> and return
+ * JSON representations of vulnerability resources. The controller delegates
+ * persistence and enrichment work to the {@code VulnerabilityRepository} and
+ * {@code EnrichmentService} respectively.
+ */
 @RestController
 @RequestMapping("/api/v1/vulnerabilities")
 @RequiredArgsConstructor

--- a/src/main/java/dev/prasadgaikwad/vulnbench/domain/Vulnerability.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/domain/Vulnerability.java
@@ -10,6 +10,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+/**
+ * Persistent JPA entity representing a software vulnerability (CVE) and its
+ * associated metadata used throughout the application.
+ *
+ * <p>Fields include canonical identifiers, scoring metrics (CVSS/EPSS), AI
+ * enrichment outputs, related source links, and relationships to affected
+ * packages and CWEs.</p>
+ */
 @Entity
 @Table(name = "vulnerability", indexes = {
         @Index(name = "idx_vuln_cve_id", columnList = "cve_id", unique = true),

--- a/src/main/java/dev/prasadgaikwad/vulnbench/repository/VulnerabilityRepository.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/repository/VulnerabilityRepository.java
@@ -2,6 +2,7 @@ package dev.prasadgaikwad.vulnbench.repository;
 
 import dev.prasadgaikwad.vulnbench.domain.Vulnerability;
 import dev.prasadgaikwad.vulnbench.domain.CvssV3Severity;
+import dev.prasadgaikwad.vulnbench.domain.VulnSource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -175,7 +176,7 @@ public interface VulnerabilityRepository extends JpaRepository<Vulnerability, UU
 
     /**
      * Counts vulnerabilities by their primary data source (e.g. "NVD" or "GHSA").
-     * Matches against the source type stored in {@link dev.prasadgaikwad.vulnbench.domain.VulnSource}.
+     * Matches against the source type stored in {@link VulnSource}.
      *
      * @param sourceType the source type string
      * @return count of vulnerabilities from that source

--- a/src/main/java/dev/prasadgaikwad/vulnbench/security/SecurityConfig.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/security/SecurityConfig.java
@@ -9,6 +9,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * Application security configuration. Sets up URL-based authorization rules,
+ * form login, OAuth2 login integration, and the password encoder bean used for
+ * local authentication. The class centralizes Spring Security wiring for both
+ * the web UI and the REST API surface.
+ */
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor

--- a/src/main/java/dev/prasadgaikwad/vulnbench/web/DashboardController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/web/DashboardController.java
@@ -4,6 +4,7 @@ import dev.prasadgaikwad.vulnbench.domain.CvssV3Severity;
 import dev.prasadgaikwad.vulnbench.domain.Vulnerability;
 import dev.prasadgaikwad.vulnbench.repository.VulnerabilityRepository;
 import dev.prasadgaikwad.vulnbench.service.EnrichmentService;
+import dev.prasadgaikwad.vulnbench.service.ExportService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,6 +19,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.List;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 
 /**
  * Controller for the Vulnerability Triage Dashboard Web UI.
@@ -31,7 +37,7 @@ public class DashboardController {
 
     private final VulnerabilityRepository vulnerabilityRepository;
     private final EnrichmentService enrichmentService;
-    private final dev.prasadgaikwad.vulnbench.service.ExportService exportService;
+    private final ExportService exportService;
 
     /**
      * Main dashboard entry point. Renders the full page with filtered vulnerability results.
@@ -81,7 +87,7 @@ public class DashboardController {
      * @param model Spring UI model
      * @return the ai-intelligence fragment
      */
-    @org.springframework.web.bind.annotation.PostMapping("/vulnerability/{cveId}/enrich")
+    @PostMapping("/vulnerability/{cveId}/enrich")
     public String triggerEnrichment(@PathVariable("cveId") String cveId, Model model) {
         Vulnerability vulnerability = vulnerabilityRepository.findByCveId(cveId)
                 .orElseThrow(() -> new IllegalArgumentException("Vulnerability not found: " + cveId));
@@ -136,13 +142,13 @@ public class DashboardController {
     }
 
     @GetMapping("/export")
-    public org.springframework.http.ResponseEntity<byte[]> export(
+    public ResponseEntity<byte[]> export(
             @RequestParam(value = "severity", required = false) String severity,
             @RequestParam(value = "ecosystem", required = false) String ecosystem,
             @RequestParam(value = "q", required = false) String query,
             @RequestParam(value = "format", defaultValue = "csv") String format) {
 
-        java.util.List<Vulnerability> vulnerabilities;
+        List<Vulnerability> vulnerabilities;
         if (query != null && !query.isBlank()) {
             vulnerabilities = vulnerabilityRepository.fullTextSearchUnpaged(query);
         } else {
@@ -173,11 +179,11 @@ public class DashboardController {
             extension = "csv";
         }
 
-        org.springframework.http.HttpHeaders headers = new org.springframework.http.HttpHeaders();
-        headers.add(org.springframework.http.HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=vulnerability-export." + extension);
-        headers.add(org.springframework.http.HttpHeaders.CONTENT_TYPE, contentType);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=vulnerability-export." + extension);
+        headers.add(HttpHeaders.CONTENT_TYPE, contentType);
 
-        return new org.springframework.http.ResponseEntity<>(content, headers, org.springframework.http.HttpStatus.OK);
+        return new ResponseEntity<>(content, headers, HttpStatus.OK);
     }
 
     /**

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerSecurityTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerSecurityTest.java
@@ -16,6 +16,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.springframework.context.annotation.Import;
 import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+import dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService;
+import dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService;
 
 /**
  * Security-focused tests for AdminController to ensure unauthenticated users are
@@ -39,10 +41,10 @@ class AdminControllerSecurityTest {
 	private SlackService slackService;
 
 	@MockitoBean
-	private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+	private CustomOAuth2UserService customOAuth2UserService;
 
 	@MockitoBean
-	private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
+	private CustomUserDetailsService userDetailsService;
 
 	@Test
 	void trigger_anonymous_redirectsToLoginOrForbidden() throws Exception {

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerSecurityTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerSecurityTest.java
@@ -1,0 +1,74 @@
+package dev.prasadgaikwad.vulnbench.api;
+
+import dev.prasadgaikwad.vulnbench.batch.IngestService;
+import dev.prasadgaikwad.vulnbench.notification.slack.SlackService;
+import dev.prasadgaikwad.vulnbench.repository.IngestStateRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.springframework.context.annotation.Import;
+import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+
+/**
+ * Security-focused tests for AdminController to ensure unauthenticated users are
+ * redirected to the login page (form-based auth) and that the security filter
+ * chain is wired correctly for admin endpoints.
+ */
+@WebMvcTest(AdminController.class)
+@Import(SecurityConfig.class)
+class AdminControllerSecurityTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private IngestService ingestService;
+
+	@MockitoBean
+	private IngestStateRepository ingestStateRepo;
+
+	@MockitoBean
+	private SlackService slackService;
+
+	@MockitoBean
+	private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+
+	@MockitoBean
+	private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
+
+	@Test
+	void trigger_anonymous_redirectsToLoginOrForbidden() throws Exception {
+		mockMvc.perform(post("/api/v1/admin/ingest/trigger")).andExpect(result -> {
+			int status = result.getResponse().getStatus();
+			// depending on CSRF/session state the framework may either redirect to login (302)
+			// or respond with Forbidden (403) for POSTs. Accept either as valid unauthenticated behaviour.
+			org.junit.jupiter.api.Assertions.assertTrue(status == 302 || status == 403,
+					"expected 302 or 403 but was " + status);
+		});
+	}
+
+	@Test
+	void status_anonymous_redirectsToLogin() throws Exception {
+		mockMvc.perform(get("/api/v1/admin/ingest/status"))
+				.andExpect(status().isFound())
+				.andExpect(redirectedUrlPattern("**/login"));
+	}
+
+	@Test
+	void slackTest_anonymous_redirectsToLoginOrForbidden() throws Exception {
+		mockMvc.perform(post("/api/v1/admin/ingest/slack/test")).andExpect(result -> {
+			int status = result.getResponse().getStatus();
+			org.junit.jupiter.api.Assertions.assertTrue(status == 302 || status == 403,
+					"expected 302 or 403 but was " + status);
+		});
+	}
+}
+

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerTest.java
@@ -22,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.springframework.context.annotation.Import;
 import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+import dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService;
 
 @WebMvcTest(AdminController.class)
 @Import(SecurityConfig.class)
@@ -35,7 +36,7 @@ class AdminControllerTest {
     private IngestService ingestService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+    private CustomOAuth2UserService customOAuth2UserService;
 
     @MockitoBean
     private IngestStateRepository ingestStateRepo;

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityControllerSecurityTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityControllerSecurityTest.java
@@ -15,6 +15,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.springframework.context.annotation.Import;
 import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+import dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService;
+import dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService;
 
 @WebMvcTest(VulnerabilityController.class)
 @Import(SecurityConfig.class)
@@ -30,10 +32,10 @@ class VulnerabilityControllerSecurityTest {
     private EnrichmentService enrichmentService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+    private CustomOAuth2UserService customOAuth2UserService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
+    private CustomUserDetailsService userDetailsService;
 
     @Test
     void listAnonymous_redirectsToLogin() throws Exception {

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityControllerSecurityTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityControllerSecurityTest.java
@@ -1,0 +1,61 @@
+package dev.prasadgaikwad.vulnbench.api;
+
+import dev.prasadgaikwad.vulnbench.repository.VulnerabilityRepository;
+import dev.prasadgaikwad.vulnbench.service.EnrichmentService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.springframework.context.annotation.Import;
+import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+
+@WebMvcTest(VulnerabilityController.class)
+@Import(SecurityConfig.class)
+class VulnerabilityControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private VulnerabilityRepository vulnRepo;
+
+    @MockitoBean
+    private EnrichmentService enrichmentService;
+
+    @MockitoBean
+    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+
+    @MockitoBean
+    private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
+
+    @Test
+    void listAnonymous_redirectsToLogin() throws Exception {
+        mockMvc.perform(get("/api/v1/vulnerabilities"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    void searchAnonymous_redirectsToLogin() throws Exception {
+        mockMvc.perform(get("/api/v1/vulnerabilities/search").param("q", "openssl"))
+                .andExpect(status().isFound())
+                .andExpect(redirectedUrlPattern("**/login"));
+    }
+
+    @Test
+    void enrichByCveId_anonymous_redirectsToLogin() throws Exception {
+        mockMvc.perform(post("/api/v1/vulnerabilities/enrich/CVE-2024-TEST")).andExpect(result -> {
+            int status = result.getResponse().getStatus();
+            org.junit.jupiter.api.Assertions.assertTrue(status == 302 || status == 403,
+                    "expected 302 or 403 but was " + status);
+        });
+    }
+}
+

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityControllerWebMvcTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityControllerWebMvcTest.java
@@ -25,6 +25,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+import dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService;
+import dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService;
 
 @WebMvcTest(VulnerabilityController.class)
 @Import(SecurityConfig.class)
@@ -41,10 +43,10 @@ class VulnerabilityControllerWebMvcTest {
     private EnrichmentService enrichmentService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+    private CustomOAuth2UserService customOAuth2UserService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
+    private CustomUserDetailsService userDetailsService;
 
     @Test
     void listVulnerabilities_returnsPagedJson() throws Exception {

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityControllerWebMvcTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/VulnerabilityControllerWebMvcTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -62,6 +63,19 @@ class VulnerabilityControllerWebMvcTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].cveId").value("CVE-2024-TEST"))
                 .andExpect(jsonPath("$.content[0].title").value("Example vuln"));
+    }
+
+    @Test
+    void listVulnerabilities_sizeCappedAt100() throws Exception {
+        // Return empty page so response is still OK
+        when(vulnRepo.findWithFilters(isNull(), isNull(), any(org.springframework.data.domain.Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of()));
+
+        mockMvc.perform(get("/api/v1/vulnerabilities").param("page", "0").param("size", "200"))
+                .andExpect(status().isOk());
+
+        // Verify controller capped the page size to 100 when building pageable
+        org.mockito.Mockito.verify(vulnRepo).findWithFilters(isNull(), isNull(), argThat(p -> p.getPageSize() == 100));
     }
 }
 

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/WatchlistControllerSecurityTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/WatchlistControllerSecurityTest.java
@@ -1,0 +1,60 @@
+package dev.prasadgaikwad.vulnbench.api;
+
+import dev.prasadgaikwad.vulnbench.service.WatchlistService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.springframework.context.annotation.Import;
+import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+
+@WebMvcTest(WatchlistController.class)
+@Import(SecurityConfig.class)
+class WatchlistControllerSecurityTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private WatchlistService watchlistService;
+
+	@MockitoBean
+	private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+
+	@MockitoBean
+	private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
+
+	@Test
+	void getWatchlist_anonymous_redirectsToLogin() throws Exception {
+		mockMvc.perform(get("/api/v1/watchlist").param("userId", "user1"))
+				.andExpect(status().isFound())
+				.andExpect(redirectedUrlPattern("**/login"));
+	}
+
+	@Test
+	void postWatchlist_anonymous_redirectsToLoginOrForbidden() throws Exception {
+		mockMvc.perform(post("/api/v1/watchlist")).andExpect(result -> {
+			int status = result.getResponse().getStatus();
+			org.junit.jupiter.api.Assertions.assertTrue(status == 302 || status == 403,
+					"expected 302 or 403 but was " + status);
+		});
+	}
+
+	@Test
+	void deleteWatchlist_anonymous_redirectsToLoginOrForbidden() throws Exception {
+		mockMvc.perform(delete("/api/v1/watchlist/{id}", java.util.UUID.randomUUID())).andExpect(result -> {
+			int status = result.getResponse().getStatus();
+			org.junit.jupiter.api.Assertions.assertTrue(status == 302 || status == 403,
+					"expected 302 or 403 but was " + status);
+		});
+	}
+}
+

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/WatchlistControllerSecurityTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/WatchlistControllerSecurityTest.java
@@ -15,6 +15,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.springframework.context.annotation.Import;
 import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+import dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService;
+import dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService;
+import java.util.UUID;
 
 @WebMvcTest(WatchlistController.class)
 @Import(SecurityConfig.class)
@@ -27,10 +30,10 @@ class WatchlistControllerSecurityTest {
 	private WatchlistService watchlistService;
 
 	@MockitoBean
-	private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+	private CustomOAuth2UserService customOAuth2UserService;
 
 	@MockitoBean
-	private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
+	private CustomUserDetailsService userDetailsService;
 
 	@Test
 	void getWatchlist_anonymous_redirectsToLogin() throws Exception {
@@ -50,7 +53,7 @@ class WatchlistControllerSecurityTest {
 
 	@Test
 	void deleteWatchlist_anonymous_redirectsToLoginOrForbidden() throws Exception {
-		mockMvc.perform(delete("/api/v1/watchlist/{id}", java.util.UUID.randomUUID())).andExpect(result -> {
+		mockMvc.perform(delete("/api/v1/watchlist/{id}", UUID.randomUUID())).andExpect(result -> {
 			int status = result.getResponse().getStatus();
 			org.junit.jupiter.api.Assertions.assertTrue(status == 302 || status == 403,
 					"expected 302 or 403 but was " + status);

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/WatchlistControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/WatchlistControllerTest.java
@@ -22,6 +22,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.springframework.context.annotation.Import;
 import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+import dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService;
+import dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService;
 
 @WebMvcTest(WatchlistController.class)
 @Import(SecurityConfig.class)
@@ -35,10 +37,10 @@ class WatchlistControllerTest {
     private WatchlistService watchlistService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+    private CustomOAuth2UserService customOAuth2UserService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
+    private CustomUserDetailsService userDetailsService;
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/AnalyticsControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/AnalyticsControllerTest.java
@@ -18,6 +18,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+import dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService;
+import dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService;
 
 /**
  * Web MVC tests for {@link AnalyticsController}.
@@ -33,10 +35,10 @@ class AnalyticsControllerTest {
     private VulnerabilityRepository vulnerabilityRepository;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+    private CustomOAuth2UserService customOAuth2UserService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
+    private CustomUserDetailsService userDetailsService;
 
     private void stubAnalyticsQueries() {
         when(vulnerabilityRepository.countBySeverity(CvssV3Severity.CRITICAL)).thenReturn(10L);

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/AuthControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/AuthControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.springframework.context.annotation.Import;
 import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+import dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService;
 
 @WebMvcTest(AuthController.class)
 @Import(SecurityConfig.class)
@@ -26,7 +27,7 @@ class AuthControllerTest {
     private CustomUserDetailsService userDetailsService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+    private CustomOAuth2UserService customOAuth2UserService;
 
     @Test
     void testLoginPage() throws Exception {

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/DashboardControllerExportTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/DashboardControllerExportTest.java
@@ -17,6 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService;
 
 @WebMvcTest(DashboardController.class)
 class DashboardControllerExportTest {
@@ -28,7 +29,7 @@ class DashboardControllerExportTest {
     private VulnerabilityRepository vulnerabilityRepository;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+    private CustomOAuth2UserService customOAuth2UserService;
 
     @MockitoBean
     private EnrichmentService enrichmentService;

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/DashboardControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/DashboardControllerTest.java
@@ -1,6 +1,7 @@
 package dev.prasadgaikwad.vulnbench.web;
 
 import dev.prasadgaikwad.vulnbench.domain.Vulnerability;
+import dev.prasadgaikwad.vulnbench.domain.CvssV3Severity;
 import dev.prasadgaikwad.vulnbench.repository.VulnerabilityRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.time.Instant;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -39,8 +41,8 @@ public class DashboardControllerTest {
                 .cveId("CVE-2024-TEST")
                 .title("Test Title")
                 .description("Test Description")
-                .publishedAt(java.time.Instant.now())
-                .cvssV3Severity(dev.prasadgaikwad.vulnbench.domain.CvssV3Severity.HIGH)
+                .publishedAt(Instant.now())
+                .cvssV3Severity(CvssV3Severity.HIGH)
                 .build();
 
         when(vulnerabilityRepository.findWithFilters(isNull(), isNull(), any(Pageable.class)))

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/UserControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/UserControllerTest.java
@@ -23,6 +23,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import dev.prasadgaikwad.vulnbench.security.SecurityConfig;
+import dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService;
+import dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService;
 
 /**
  * Web MVC tests for {@link UserController} covering all CRUD endpoints.
@@ -41,10 +43,10 @@ class UserControllerTest {
     private UserService userService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomOAuth2UserService customOAuth2UserService;
+    private CustomOAuth2UserService customOAuth2UserService;
 
     @MockitoBean
-    private dev.prasadgaikwad.vulnbench.security.CustomUserDetailsService userDetailsService;
+    private CustomUserDetailsService userDetailsService;
 
     private AppUser sampleUser() {
         return AppUser.builder().id(1L).username("alice")


### PR DESCRIPTION
This PR adds additional API security WebMvc tests and a vulnerabilities list behavior test introduced to address issue #45.

Changes:
- Add unauthenticated access tests for Admin, Watchlist, and Vulnerability controllers to assert redirects or forbidden for POST/DELETE endpoints.
- Add a WebMvc test to verify the vulnerabilities list endpoint caps the requested page size at 100.

These tests make the API security surface more robust against regressions and cover CSRF/authorization scenarios. Please review and merge to main.