### PR TITLE
feat: add admin dashboard ingest trigger (issue #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ For a deeper understanding of the concepts and workflows implemented in this pla
 
 Step-by-step instructions for configuring key integrations and features:
 
+*   **[Admin Dashboard Ingest Trigger](docs/setup/admin-ingest-trigger.md)**: Use the admin UI to manually trigger an ingestion cycle.
 *   **[OAuth2 Setup Guide](docs/setup/oauth2-setup.md)**: Enable GitHub and Google social login for the dashboard.
 *   **[Slack Integration Setup](docs/setup/slack-setup.md)**: Configure real-time vulnerability alerts in Slack.
 *   **[Auto-Remediation (GitHub) Setup](docs/setup/auto-remediation.md)**: Enable the dashboard "Generate Auto-Patch PR" workflow for dependency management.
@@ -260,6 +261,12 @@ Once the application is running, you can access the interactive API documentatio
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
 ## Changelog
+
+### 2026-05-25 — Admin Dashboard Ingest Trigger (Issue #54)
+- Added an admin-only **Trigger Ingestion** action to the dashboard with confirmation modal, progress indicator, and toast feedback.
+- The trigger action posts to `/api/v1/admin/ingest/trigger`, respects CSRF protection, and is hidden from non-admin users.
+- Added dashboard UI tests for role-based button visibility and strengthened the admin ingest controller test to verify the backend service is invoked.
+- Documented the workflow in **[Admin Dashboard Ingest Trigger](docs/setup/admin-ingest-trigger.md)**.
 
 ### 2026-05-25 — Dynamic Risk Score Engine (Issue #38)
 - **Implemented Dynamic Risk Score Engine**: Introduced a weighted risk scoring formula (40% CVSS + 40% EPSS + 20% CISA KEV) to intelligently prioritize vulnerabilities by real-world impact.

--- a/docs/setup/admin-ingest-trigger.md
+++ b/docs/setup/admin-ingest-trigger.md
@@ -1,0 +1,53 @@
+# Admin Dashboard Ingest Trigger
+
+## Overview
+
+The Admin Dashboard now includes a **Trigger Ingestion** action for manually starting a vulnerability ingest cycle.
+
+This is intended for administrators who need to pull new advisories immediately instead of waiting for the scheduled ingestion job.
+
+## How it works
+
+- The button is visible only to users with the `ADMIN` role.
+- Clicking the button opens a confirmation modal.
+- Confirming the action sends a `POST` request to:
+
+```http
+POST /api/v1/admin/ingest/trigger
+```
+
+- The request is CSRF-protected and respects the same Spring Security rules as the rest of the application.
+- A success or error toast is shown after the request completes.
+
+## What to expect
+
+After the trigger request is accepted:
+
+- The API responds with `202 Accepted`.
+- Ingestion continues asynchronously in the background.
+- You can check progress through:
+
+```http
+GET /api/v1/admin/ingest/status
+```
+
+## Audit and observability
+
+The trigger endpoint logs the action server-side so the manual ingestion request is visible in application logs and operational traces.
+
+## Testing notes
+
+When testing locally:
+
+1. Sign in with an `ADMIN` user.
+2. Open the dashboard at `/dashboard`.
+3. Click **Trigger Ingestion**.
+4. Confirm the modal action.
+5. Verify that the `202 Accepted` response is returned and the ingest status endpoint reflects the background run.
+
+## Related documentation
+
+- [OAuth2 Setup Guide](oauth2-setup.md)
+- [Slack Integration Setup](slack-setup.md)
+- [Auto-Remediation Setup Guide](auto-remediation.md)
+

--- a/src/main/java/dev/prasadgaikwad/vulnbench/api/AdminController.java
+++ b/src/main/java/dev/prasadgaikwad/vulnbench/api/AdminController.java
@@ -32,7 +32,11 @@ public class AdminController {
 
     /**
      * Triggers a full ingestion cycle for all enabled security sources.
-     * The process runs asynchronously.
+     *
+     * <p>This endpoint is intended for audited administrative use cases such as the
+     * dashboard "Trigger Ingestion" action. The request returns immediately with a
+     * 202 Accepted response while the ingest job continues asynchronously in the
+     * background.
      * 
      * @return a 202 Accepted response with a confirmation message
      */

--- a/src/main/resources/static/css/dashboard.css
+++ b/src/main/resources/static/css/dashboard.css
@@ -228,6 +228,84 @@ tr:hover td {
     cursor: not-allowed;
 }
 
+.btn-primary {
+    background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
+    color: #fff;
+    border-color: transparent;
+}
+
+.btn-primary:hover:not(:disabled) {
+    filter: brightness(1.05);
+    border-color: transparent;
+}
+
+.btn-secondary {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.btn-secondary:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.14);
+}
+
+.modal-overlay {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(2, 6, 23, 0.72);
+    backdrop-filter: blur(6px);
+    z-index: 1000;
+}
+
+.modal-box {
+    max-width: 520px;
+    width: calc(100% - 2rem);
+    padding: 2rem;
+}
+
+.ingest-progress {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--accent-primary);
+    font-size: 0.9rem;
+}
+
+.ingest-spinner {
+    width: 1rem;
+    height: 1rem;
+    border-radius: 9999px;
+    border: 2px solid rgba(56, 189, 248, 0.25);
+    border-top-color: var(--accent-primary);
+    animation: spin 0.8s linear infinite;
+}
+
+.toast {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: 2000;
+    padding: 0.85rem 1.15rem;
+    border-radius: 0.75rem;
+    font-size: 0.9rem;
+    font-weight: 500;
+    backdrop-filter: blur(10px);
+    animation: slideUp 0.3s ease;
+}
+
+.toast-success {
+    background: rgba(16, 185, 129, 0.2);
+    border: 1px solid var(--success);
+    color: var(--success);
+}
+
+.toast-error {
+    background: rgba(239, 68, 68, 0.2);
+    border: 1px solid var(--danger);
+    color: var(--danger);
+}
+
 @keyframes fadeInUp {
     from { opacity: 0; transform: translateY(20px); }
     to { opacity: 1; transform: translateY(0); }
@@ -236,6 +314,16 @@ tr:hover td {
 @keyframes fadeInDown {
     from { opacity: 0; transform: translateY(-20px); }
     to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
+@keyframes slideUp {
+    from { transform: translateY(20px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
 }
 
 /* HTMX indicator */

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -74,7 +74,16 @@
                     <button type="button" class="btn btn-secondary" onclick="exportData('json')">JSON</button>
                 </div>
             </div>
-            
+
+            <div class="input-group" style="align-items: flex-end;" sec:authorize="hasRole('ADMIN')">
+                <label>Admin</label>
+                <div style="display: flex; gap: 0.5rem; flex-wrap: wrap;">
+                    <button type="button" class="btn btn-primary" id="trigger-ingest-btn" onclick="openIngestModal()">
+                        Trigger Ingestion
+                    </button>
+                </div>
+            </div>
+
             <div style="display: flex; align-items: flex-end; padding-bottom: 0.6rem;">
                 <span class="htmx-indicator search-indicator" style="font-size: 0.8rem; color: var(--accent-primary);">
                     Refreshing...
@@ -83,13 +92,107 @@
         </section>
 
         <script>
+            const ingestModal = {
+                overlay: null,
+                confirmButton: null,
+                progress: null,
+                message: null
+            };
+
             function exportData(format) {
                 const q = document.getElementById('search').value;
                 const sev = document.getElementById('severity').value;
                 const eco = document.getElementById('ecosystem').value;
                 window.location.href = `/dashboard/export?q=${encodeURIComponent(q)}&severity=${encodeURIComponent(sev)}&ecosystem=${encodeURIComponent(eco)}&format=${format}`;
             }
+
+            function initIngestModal() {
+                ingestModal.overlay = document.getElementById('ingest-modal');
+                ingestModal.confirmButton = document.getElementById('confirm-ingest-btn');
+                ingestModal.progress = document.getElementById('ingest-progress');
+                ingestModal.message = document.getElementById('ingest-message');
+            }
+
+            function openIngestModal() {
+                if (!ingestModal.overlay) initIngestModal();
+                ingestModal.message.textContent = 'Start ingestion now? This will fetch new advisories and may create new CVE records.';
+                ingestModal.progress.style.display = 'none';
+                ingestModal.confirmButton.disabled = false;
+                ingestModal.confirmButton.textContent = 'Confirm Trigger';
+                ingestModal.overlay.style.display = 'flex';
+            }
+
+            function closeIngestModal() {
+                if (!ingestModal.overlay) initIngestModal();
+                ingestModal.overlay.style.display = 'none';
+            }
+
+            async function confirmIngest() {
+                if (!ingestModal.overlay) initIngestModal();
+                const csrfToken = document.querySelector('meta[name="_csrf"]')?.content;
+                const csrfHeader = document.querySelector('meta[name="_csrf_header"]')?.content;
+                const headers = { 'Content-Type': 'application/json' };
+
+                if (csrfToken && csrfHeader) {
+                    headers[csrfHeader] = csrfToken;
+                }
+
+                ingestModal.confirmButton.disabled = true;
+                ingestModal.confirmButton.textContent = 'Triggering...';
+                ingestModal.progress.style.display = 'flex';
+                ingestModal.message.textContent = 'Triggering ingestion. Please wait...';
+
+                try {
+                    const response = await fetch('/api/v1/admin/ingest/trigger', {
+                        method: 'POST',
+                        headers
+                    });
+                    const data = await response.json().catch(() => ({}));
+
+                    if (!response.ok) {
+                        throw new Error(data.message || 'Unable to trigger ingestion.');
+                    }
+
+                    ingestModal.message.textContent = data.message || 'Ingestion triggered successfully.';
+                    ingestModal.progress.style.display = 'none';
+                    showToast(data.message || 'Ingestion triggered successfully.', 'success');
+                    setTimeout(closeIngestModal, 1200);
+                } catch (error) {
+                    ingestModal.progress.style.display = 'none';
+                    ingestModal.confirmButton.disabled = false;
+                    ingestModal.confirmButton.textContent = 'Confirm Trigger';
+                    ingestModal.message.textContent = error.message || 'Unable to trigger ingestion.';
+                    showToast(error.message || 'Unable to trigger ingestion.', 'error');
+                }
+            }
+
+            function showToast(message, type) {
+                const toast = document.createElement('div');
+                toast.className = `toast toast-${type}`;
+                toast.textContent = message;
+                document.body.appendChild(toast);
+                setTimeout(() => toast.remove(), 4000);
+            }
+
+            document.addEventListener('DOMContentLoaded', initIngestModal);
         </script>
+
+        <div id="ingest-modal" class="modal-overlay" style="display: none;" role="dialog" aria-modal="true" aria-labelledby="ingest-modal-title" sec:authorize="hasRole('ADMIN')">
+            <div class="modal-box detail-card">
+                <h3 id="ingest-modal-title" style="margin: 0 0 1rem; color: var(--accent-primary);">Trigger Ingestion</h3>
+                <p id="ingest-message" style="color: var(--text-muted); margin-bottom: 1rem;">
+                    Start ingestion now? This will fetch new advisories and may create new CVE records.
+                </p>
+                <div id="ingest-progress" class="ingest-progress" style="display: none;">
+                    <span class="ingest-spinner" aria-hidden="true"></span>
+                    <span>Triggering ingestion...</span>
+                </div>
+                <div style="display: flex; gap: 1rem; margin-top: 1.5rem; justify-content: flex-end;">
+                    <button class="btn btn-primary" id="confirm-ingest-btn" onclick="confirmIngest()">Confirm Trigger</button>
+                    <button class="btn btn-secondary" onclick="closeIngestModal()">Cancel</button>
+                </div>
+            </div>
+        </div>
 
         <div class="table-container" id="vuln-table-body">
             <!-- Included via fragment initially -->

--- a/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/api/AdminControllerTest.java
@@ -53,8 +53,7 @@ class AdminControllerTest {
                 .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.message").exists());
 
-        // Note: runAsync makes verifying the exact call tricky in a fast mock test,
-        // but we at least know the endpoint returns 202.
+        verify(ingestService, timeout(1000)).runFullIngest();
     }
 
     @Test

--- a/src/test/java/dev/prasadgaikwad/vulnbench/web/DashboardControllerTest.java
+++ b/src/test/java/dev/prasadgaikwad/vulnbench/web/DashboardControllerTest.java
@@ -21,6 +21,8 @@ import java.time.Instant;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -68,5 +70,43 @@ public class DashboardControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(view().name("dashboard/fragments/vuln-table :: results"))
                 .andExpect(model().attributeExists("vulnerabilities"));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void testDashboardIndex_adminSeesTriggerIngestionButton() throws Exception {
+        Vulnerability v = Vulnerability.builder()
+                .cveId("CVE-2024-ADMIN")
+                .title("Admin View Title")
+                .description("Admin View Description")
+                .publishedAt(Instant.now())
+                .cvssV3Severity(CvssV3Severity.HIGH)
+                .build();
+
+        when(vulnerabilityRepository.findWithFilters(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(v)));
+
+        mockMvc.perform(get("/dashboard"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Trigger Ingestion")))
+                .andExpect(content().string(containsString("id=\"trigger-ingest-btn\"")));
+    }
+
+    @Test
+    void testDashboardIndex_nonAdminDoesNotSeeTriggerIngestionButton() throws Exception {
+        Vulnerability v = Vulnerability.builder()
+                .cveId("CVE-2024-USER")
+                .title("User View Title")
+                .description("User View Description")
+                .publishedAt(Instant.now())
+                .cvssV3Severity(CvssV3Severity.HIGH)
+                .build();
+
+        when(vulnerabilityRepository.findWithFilters(isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(v)));
+
+        mockMvc.perform(get("/dashboard"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(not(containsString("id=\"trigger-ingest-btn\""))));
     }
 }


### PR DESCRIPTION
## Summary
Adds an admin-only **Trigger Ingestion** action to the dashboard so admins can manually start an ingest cycle from the UI instead of using the API directly.

## What changed

### Dashboard UI
- Added an admin-only **Trigger Ingestion** button on the dashboard.
- Added a confirmation modal before starting ingest.
- Added progress feedback while the request is in flight.
- Added success/error toast notifications.
- The UI posts to `POST /api/v1/admin/ingest/trigger` with CSRF headers.

### Backend / docs
- Added javadocs to the admin trigger endpoint to clarify the audited asynchronous behavior.
- Added a short setup guide: `docs/setup/admin-ingest-trigger.md`.
- Updated the README setup guides and changelog.

### Tests
- `DashboardControllerTest`
  - verifies the trigger button is visible to `ADMIN`
  - verifies the trigger button is hidden from non-admin users
- `AdminControllerTest`
  - verifies `runFullIngest()` is invoked when the endpoint is called
- Full test suite passes locally

## Verification
- `./gradlew test --tests dev.prasadgaikwad.vulnbench.web.DashboardControllerTest --tests dev.prasadgaikwad.vulnbench.api.AdminControllerTest`
- `./gradlew test`

## Notes
- The actual ingest run remains asynchronous and continues to be governed by Spring Security and CSRF protection.
- This change keeps the admin action visible only to users with `ADMIN` role.

Closes #54