### PR TITLE
Fix search bar: make it more intuitive and move export options to table

### DIFF
--- a/src/main/resources/static/css/dashboard.css
+++ b/src/main/resources/static/css/dashboard.css
@@ -869,3 +869,70 @@ tr:hover td {
     from { opacity: 0; transform: scale(0.95) translateY(-10px); }
     to { opacity: 1; transform: scale(1) translateY(0); }
 }
+
+/* Rich Search Input & Components */
+.search-input-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    border-radius: 0.75rem;
+    background: var(--input-bg);
+    border: 1px solid var(--glass-border);
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.search-input-wrapper:hover {
+    border-color: rgba(56, 189, 248, 0.4);
+    box-shadow: 0 0 12px rgba(56, 189, 248, 0.1);
+}
+
+.search-input-wrapper:focus-within {
+    border-color: var(--accent-primary);
+    box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2), 0 4px 12px rgba(56, 189, 248, 0.1);
+    background: rgba(15, 23, 42, 0.6);
+}
+
+.search-icon {
+    position: absolute;
+    left: 1rem;
+    color: var(--text-muted);
+    transition: color 0.3s ease;
+    pointer-events: none;
+}
+
+.search-input-wrapper:focus-within .search-icon {
+    color: var(--accent-primary);
+}
+
+.rich-search-input {
+    width: 100%;
+    padding: 0.8rem 2.5rem 0.8rem 2.75rem;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    font-size: 0.95rem;
+    color: var(--text-main);
+    outline: none;
+}
+
+.clear-btn {
+    position: absolute;
+    right: 0.75rem;
+    background: transparent;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    padding: 0.25rem;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s;
+}
+
+.clear-btn:hover {
+    color: var(--danger);
+    background: rgba(239, 68, 68, 0.1);
+}
+

--- a/src/main/resources/templates/dashboard/fragments/vuln-table.html
+++ b/src/main/resources/templates/dashboard/fragments/vuln-table.html
@@ -1,4 +1,27 @@
 <div th:fragment="results" id="vuln-table-results">
+    <div style="display: flex; justify-content: space-between; align-items: center; padding: 1.25rem 1.5rem; background: var(--table-header-bg); border-bottom: 1px solid var(--glass-border);">
+        <div style="font-weight: 600; color: var(--text-main); font-size: 1rem; display: flex; align-items: center; gap: 0.5rem;">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color: var(--accent-primary);">
+                <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+            </svg>
+            Vulnerability Records
+        </div>
+        <div style="display: flex; gap: 0.5rem; align-items: center;">
+            <span style="font-size: 0.75rem; font-weight: 600; color: var(--text-muted); text-transform: uppercase; letter-spacing: 0.05em;">Export:</span>
+            <button type="button" class="btn btn-secondary" onclick="exportData('csv')" style="padding: 0.35rem 0.75rem; font-size: 0.8rem; display: flex; align-items: center; gap: 0.3rem;">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                CSV
+            </button>
+            <button type="button" class="btn btn-secondary" onclick="exportData('pdf')" style="padding: 0.35rem 0.75rem; font-size: 0.8rem; display: flex; align-items: center; gap: 0.3rem;">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                PDF
+            </button>
+            <button type="button" class="btn btn-secondary" onclick="exportData('json')" style="padding: 0.35rem 0.75rem; font-size: 0.8rem; display: flex; align-items: center; gap: 0.3rem;">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                JSON
+            </button>
+        </div>
+    </div>
     <table>
         <thead>
             <tr>

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -27,8 +27,8 @@
         <section class="controls">
             <div class="input-group" style="flex-grow: 1;">
                 <label for="search">Search CVE / Title</label>
-                <div style="position: relative; display: flex; align-items: center;">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="position: absolute; left: 0.75rem; color: var(--text-muted); pointer-events: none;">
+                <div class="search-input-wrapper">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="search-icon">
                         <circle cx="11" cy="11" r="8"/>
                         <path d="m21 21-4.3-4.3"/>
                     </svg>
@@ -40,7 +40,13 @@
                            hx-target="#vuln-table-body"
                            hx-include="[name='severity'], [name='ecosystem']"
                            hx-indicator=".search-indicator"
-                           style="padding-left: 2.5rem; width: 100%;">
+                           class="rich-search-input">
+                    <button type="button" id="clear-search" class="clear-btn" style="display: none;">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <line x1="18" y1="6" x2="6" y2="18"/>
+                            <line x1="6" y1="6" x2="18" y2="18"/>
+                        </svg>
+                    </button>
                 </div>
             </div>
 
@@ -176,7 +182,30 @@
                 setTimeout(() => toast.remove(), 4000);
             }
 
-            document.addEventListener('DOMContentLoaded', initIngestModal);
+            document.addEventListener('DOMContentLoaded', () => {
+                initIngestModal();
+                
+                const searchInput = document.getElementById('search');
+                const clearBtn = document.getElementById('clear-search');
+                
+                if (searchInput && clearBtn) {
+                    const toggleClearBtn = () => {
+                        clearBtn.style.display = searchInput.value ? 'flex' : 'none';
+                    };
+                    
+                    searchInput.addEventListener('input', toggleClearBtn);
+                    searchInput.addEventListener('keyup', toggleClearBtn);
+                    
+                    clearBtn.addEventListener('click', () => {
+                        searchInput.value = '';
+                        toggleClearBtn();
+                        searchInput.dispatchEvent(new Event('keyup'));
+                        searchInput.focus();
+                    });
+                    
+                    toggleClearBtn();
+                }
+            });
         </script>
 
         <div class="table-container" id="vuln-table-body">

--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -27,14 +27,21 @@
         <section class="controls">
             <div class="input-group" style="flex-grow: 1;">
                 <label for="search">Search CVE / Title</label>
-                <input type="text" id="search" name="q" 
-                       placeholder="Type to search..." 
-                       th:value="${searchQuery}"
-                       hx-get="/dashboard/results" 
-                       hx-trigger="keyup changed delay:300ms" 
-                       hx-target="#vuln-table-body"
-                       hx-include="[name='severity'], [name='ecosystem']"
-                       hx-indicator=".search-indicator">
+                <div style="position: relative; display: flex; align-items: center;">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="position: absolute; left: 0.75rem; color: var(--text-muted); pointer-events: none;">
+                        <circle cx="11" cy="11" r="8"/>
+                        <path d="m21 21-4.3-4.3"/>
+                    </svg>
+                    <input type="text" id="search" name="q" 
+                           placeholder="Type to search by CVE ID or title..." 
+                           th:value="${searchQuery}"
+                           hx-get="/dashboard/results" 
+                           hx-trigger="keyup changed delay:300ms" 
+                           hx-target="#vuln-table-body"
+                           hx-include="[name='severity'], [name='ecosystem']"
+                           hx-indicator=".search-indicator"
+                           style="padding-left: 2.5rem; width: 100%;">
+                </div>
             </div>
 
             <div class="input-group">
@@ -64,15 +71,6 @@
                     <option value="Go">Go</option>
                     <option value="NuGet">NuGet</option>
                 </select>
-            </div>
-            
-            <div class="input-group" style="align-items: flex-end;">
-                <label>Export</label>
-                <div style="display: flex; gap: 0.5rem;">
-                    <button type="button" class="btn btn-secondary" onclick="exportData('csv')">CSV</button>
-                    <button type="button" class="btn btn-secondary" onclick="exportData('pdf')">PDF</button>
-                    <button type="button" class="btn btn-secondary" onclick="exportData('json')">JSON</button>
-                </div>
             </div>
 
             <div style="display: flex; align-items: flex-end; padding-bottom: 0.6rem;">


### PR DESCRIPTION
Closes #61. Refactors the search/filter controls to remove the export options and place the Export (CSV, PDF, JSON) actions cleanly on the vulnerabilities table. Adds a magnifying glass search icon inside the search input field for an intuitive search experience.