### PR TITLE
Support markdown formatting in CVE details

### DIFF
--- a/src/main/resources/static/css/dashboard.css
+++ b/src/main/resources/static/css/dashboard.css
@@ -1087,3 +1087,54 @@ tr:hover td {
     background: rgba(239, 68, 68, 0.1);
 }
 
+/* Markdown rendering styles */
+.markdown-content p {
+    margin-bottom: 0.85rem;
+    line-height: 1.7;
+}
+.markdown-content p:last-child {
+    margin-bottom: 0;
+}
+.markdown-content ul, .markdown-content ol {
+    margin-bottom: 0.85rem;
+    padding-left: 1.5rem;
+}
+.markdown-content li {
+    margin-bottom: 0.35rem;
+}
+.markdown-content li:last-child {
+    margin-bottom: 0;
+}
+.markdown-content a {
+    color: var(--accent-primary);
+    text-decoration: none;
+    transition: color var(--transition-speed);
+}
+.markdown-content a:hover {
+    color: var(--accent-secondary);
+    text-decoration: underline;
+}
+.markdown-content code {
+    background: rgba(56, 189, 248, 0.1);
+    color: var(--accent-primary);
+    padding: 0.15rem 0.35rem;
+    border-radius: 0.25rem;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 0.85rem;
+}
+.markdown-content pre {
+    background: rgba(15, 23, 42, 0.5);
+    border: 1px solid var(--glass-border);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    overflow-x: auto;
+    margin-bottom: 0.85rem;
+}
+.markdown-content pre code {
+    background: transparent;
+    color: inherit;
+    padding: 0;
+    font-size: 0.85rem;
+}
+
+

--- a/src/main/resources/templates/dashboard/vulnerability-detail.html
+++ b/src/main/resources/templates/dashboard/vulnerability-detail.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" th:href="@{/css/dashboard.css}">
     <script th:src="@{/js/theme.js}"></script>
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
 <body>
     <div class="container">
@@ -54,9 +55,9 @@
                          hx-target="#ai-section"
                          hx-swap="outerHTML"
                          class="ai-box" style="text-align: center; padding: 2rem;">
-                         <div class="spinner" style="margin: 0 auto 1rem;"></div>
-                         <p style="color: var(--accent-primary); font-weight: 600;">AI model is analyzing the vulnerability...</p>
-                         <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.5rem;">This usually takes 5-10 seconds.</p>
+                          <div class="spinner" style="margin: 0 auto 1rem;"></div>
+                          <p style="color: var(--accent-primary); font-weight: 600;">AI model is analyzing the vulnerability...</p>
+                          <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.5rem;">This usually takes 5-10 seconds.</p>
                     </div>
 
                     <!-- Case 1: AI Data Available (Only show if not processing) -->
@@ -79,7 +80,7 @@
                                 </button>
 
                             </p>
-                            <p th:text="${vuln.aiSummary}" style="font-size: 0.95rem; line-height: 1.6;">AI generated summary...</p>
+                            <div class="markdown-content" th:text="${vuln.aiSummary}" style="font-size: 0.95rem; line-height: 1.6; color: var(--text-main);">AI generated summary...</div>
                         </div>
                         <div th:if="${vuln.remediationAdvice}">
                             <p style="font-weight: 600; color: var(--text-main); margin-bottom: 0.8rem;">Remediation Advice</p>
@@ -149,7 +150,7 @@
 
                 <div class="detail-card">
                     <h3 style="margin-bottom: 1rem; color: var(--accent-primary);">Description</h3>
-                    <p th:text="${vuln.description}" style="white-space: pre-wrap; font-size: 0.95rem; line-height: 1.7; color: var(--text-main);">Full description...</p>
+                    <div class="markdown-content" th:text="${vuln.description}" style="font-size: 0.95rem; line-height: 1.7; color: var(--text-main);">Full description...</div>
                 </div>
 
                 <div class="detail-card">
@@ -260,5 +261,28 @@
             </aside>
         </div>
     </div>
+    <script>
+        function renderMarkdown() {
+            document.querySelectorAll('.markdown-content').forEach(function(el) {
+                if (el.dataset.parsed === 'true') return;
+                var rawMarkdown = el.textContent;
+                el.innerHTML = marked.parse(rawMarkdown);
+                el.dataset.parsed = 'true';
+            });
+        }
+
+        // Run on initial load
+        document.addEventListener('DOMContentLoaded', function() {
+            renderMarkdown();
+        });
+
+        // Fallback execution if DOMContentLoaded already fired
+        renderMarkdown();
+
+        // Run after HTMX swaps (specifically for the AI intelligence box)
+        document.body.addEventListener('htmx:afterSwap', function(evt) {
+            renderMarkdown();
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Closes #63. Renders CVE descriptions and AI summaries as Markdown client-side using marked.js.